### PR TITLE
feat(ProjectAPI): remove querying smart contract for user eligibility

### DIFF
--- a/src/domain/traits/contracts_interface.rs
+++ b/src/domain/traits/contracts_interface.rs
@@ -1,4 +1,4 @@
-use crate::domain::{Action, ContributionId, Contributor, ContributorId};
+use crate::domain::{Action, Contributor, ContributorId};
 
 use anyhow::Result;
 use async_trait::async_trait;
@@ -12,15 +12,6 @@ pub trait ContributionManager {
         actions: &[Action],
         wait_for_acceptance: bool,
     ) -> Result<String>;
-}
-
-/// Manage Contributions existence
-#[async_trait]
-pub trait ContributionViewer {
-    async fn get_eligible_contributions(
-        &self,
-        contributor_id: &ContributorId,
-    ) -> Result<Vec<ContributionId>>;
 }
 
 /// Manage User registration informations

--- a/src/starknet/domain_implementation/contributions.rs
+++ b/src/starknet/domain_implementation/contributions.rs
@@ -7,10 +7,7 @@ use starknet::{
 
 use crate::{
     domain::*,
-    starknet::{
-        contract_administrator::ContractAdministrator, contract_viewer::ContractViewer,
-        contributions_contract_address,
-    },
+    starknet::{contract_administrator::ContractAdministrator, contributions_contract_address},
 };
 
 #[async_trait]
@@ -76,32 +73,5 @@ impl From<&Action> for Call {
                 ],
             },
         }
-    }
-}
-
-#[async_trait]
-impl ContributionViewer for ContractViewer {
-    async fn get_eligible_contributions(
-        &self,
-        contributor_id: &ContributorId,
-    ) -> Result<Vec<ContributionId>> {
-        let contributor_id: (FieldElement, FieldElement) = contributor_id.into();
-
-        let mut results = self
-            .call(
-                "eligible_contributions",
-                vec![contributor_id.0, contributor_id.1],
-            )
-            .await
-            .map_err(anyhow::Error::msg)?
-            .into_iter();
-
-        const CONTRIBUTION_SIZE: usize = 6;
-        results.next(); // contributions_len
-
-        Ok(results
-            .step_by(CONTRIBUTION_SIZE)
-            .map(|x| x.to_string())
-            .collect())
     }
 }

--- a/src/starknet/mod.rs
+++ b/src/starknet/mod.rs
@@ -21,8 +21,6 @@ pub use model::*;
 
 pub use contract_administrator::ContractAdministrator;
 
-use self::contract_viewer::ContractViewer;
-
 pub fn make_account_from_env() -> impl Account {
     let private_key = env::var("PRIVATE_KEY").expect("PRIVATE_KEY must be set");
     let account_address = env::var("ACCOUNT_ADDRESS").expect("ACCOUNT_ADDRESS must be set");
@@ -60,7 +58,6 @@ pub fn sequencer() -> SequencerGatewayProvider {
 pub struct API<'a> {
     registry: Box<dyn ContributorRegistryViewer + Sync + Send + 'a>,
     oracle: Box<dyn ContributionManager + Sync + Send + 'a>,
-    contributions_viewer: Box<dyn ContributionViewer + Sync + Send + 'a>,
     profile_viewer: Box<dyn ContributorProfileViewer + Sync + Send + 'a>,
 }
 
@@ -72,7 +69,6 @@ impl<'a> API<'a> {
                 account,
                 contributions_contract_address(),
             )),
-            contributions_viewer: Box::new(ContractViewer::new(contributions_contract_address())),
             profile_viewer: Box::new(domain_implementation::Profile::default()),
         }
     }
@@ -87,14 +83,5 @@ impl<'a> API<'a> {
     ) -> Option<Contributor> {
         let account = self.profile_viewer.get_account(contributor_id).await?;
         self.registry.get_user_information(account).await
-    }
-
-    pub async fn get_eligible_contributions(
-        &self,
-        contributor_id: &ContributorId,
-    ) -> Result<Vec<ContributionId>> {
-        self.contributions_viewer
-            .get_eligible_contributions(contributor_id)
-            .await
     }
 }


### PR DESCRIPTION
I chose to remove the unused code. Which means the whole `ContributionViewer` trait. Debatable in this case, but usually we should get rid of things we don't use