### PR TITLE
add timeout for github requests and remove confirmation observer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-export DATABASE_URL=postgres://postgres:postgres@localhost/deathnote_contributions_db           # URL to the database
+export DATABASE_URL=postgres://postgres:postgres@localhost/marketplace_db                       # URL to the database
 export PRIVATE_KEY=0xeb1167b367a9c3787c65c1e582e2e662                                           # Private key of the back-end account
 export ACCOUNT_ADDRESS=0x0256d6dde4bd3b9fc870c8bbc866b1fef9d386c4d7322f539e089461e9a205ca       # Account of the feeder back-end responsible of pushing contributions in the smart contract
 export JSON_RPC_URI=http://127.0.0.1:5050/                                                      # URI to the JSON RPC node

--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,7 @@ APIBARA_URL="http://localhost:7171"                                             
 export API_KEY=ROOT
 export API_URL="http://localhost:8000"
 export LOGS=terminal
-SLOG_CHANNEL_SIZE=1024
+export SLOG_CHANNEL_SIZE=1024
 
 export GITHUB_TOKEN="YOUR_PERSONAL_ACCESS_TOKEN"
 

--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,7 @@ APIBARA_URL="http://localhost:7171"                                             
 export API_KEY=ROOT
 export API_URL="http://localhost:8000"
 export LOGS=terminal
+SLOG_CHANNEL_SIZE=1024
 
 export GITHUB_TOKEN="YOUR_PERSONAL_ACCESS_TOKEN"
 

--- a/marketplace-indexer/docker-compose.yml
+++ b/marketplace-indexer/docker-compose.yml
@@ -2,6 +2,7 @@ version: '3'
 
 services:
   mongo:
+    container_name: apibara-server-mongo
     image: mongo:latest
     restart: always
     environment:
@@ -13,7 +14,8 @@ services:
       - ./_docker/apibara_mongodb:/data/db
 
   apibara:
-    build: https://github.com/AnthonyBuisset/apibara.git#main
+    container_name: apibara-server
+    image: docker.io/onlydustxyz/apibara:v1.0.0
     restart: always
     command: start --config /usr/etc/apibara/configuration.toml
     environment:

--- a/marketplace-indexer/src/domain/obervers/composite.rs
+++ b/marketplace-indexer/src/domain/obervers/composite.rs
@@ -1,17 +1,11 @@
 use std::sync::Arc;
 
-use log::info;
-
 use super::*;
 
 pub struct ObserverComposite(Vec<Arc<dyn Observer>>);
 
 impl ObserverComposite {
 	pub fn new(observers: Vec<Arc<dyn Observer>>) -> Self {
-		info!(
-			"ObserverComposite created with {} observers",
-			observers.len()
-		);
 		Self(observers)
 	}
 }

--- a/marketplace-indexer/src/domain/obervers/confirmed.rs
+++ b/marketplace-indexer/src/domain/obervers/confirmed.rs
@@ -1,5 +1,3 @@
-use log::info;
-
 use super::{Event, Observer};
 use std::{
 	collections::VecDeque,
@@ -39,10 +37,6 @@ impl Observer for WithBockConfirmationCount {
 		while let Some((_, event_block)) = self.peek() {
 			if block_number >= event_block + self.confirmation_blocks_count {
 				let (event, event_block) = self.events_mut().pop_back().unwrap();
-				info!(
-					"Block confirmed, calling underlying observer with event {}",
-					event
-				);
 				self.observer.on_new_event(&event, event_block);
 			} else {
 				return;

--- a/marketplace-indexer/src/domain/obervers/contribution_event_store_logger.rs
+++ b/marketplace-indexer/src/domain/obervers/contribution_event_store_logger.rs
@@ -1,12 +1,10 @@
-use log::{error, info};
+use log::error;
 
 use super::*;
 use marketplace_domain::EventStore;
 
 impl<ES: EventStore<Contribution>> Observer for ES {
 	fn on_new_event(&self, event: &Event, _block_number: u64) {
-		info!("EventStore observer received event {}", event);
-
 		let Event::Contribution(event) = event;
 		let id = match event {
 			ContributionEvent::Created {
@@ -28,8 +26,6 @@ impl<ES: EventStore<Contribution>> Observer for ES {
 				"Failed to append {event} to the store: {}",
 				error.to_string()
 			);
-		} else {
-			info!("Event successfully appended in event store");
 		}
 	}
 }

--- a/marketplace-indexer/src/main.rs
+++ b/marketplace-indexer/src/main.rs
@@ -72,8 +72,6 @@ fn build_contribution_observers(
 	database: Arc<database::Client>,
 	github: Arc<github::Client>,
 ) -> Arc<dyn BlockchainObserver> {
-	let confirmation_blocks_count = 1;
-
 	let contribution_projector = ContributionProjector::new(database.clone(), github);
 
 	let contribution_repository: Arc<dyn Repository<Contribution>> =
@@ -87,11 +85,9 @@ fn build_contribution_observers(
 
 	let observer = BlockchainObserverComposite::new(vec![
 		Arc::new(BlockchainLogger::default()),
-		database.confirmed(confirmation_blocks_count),
-		Arc::new(ContributionObserver::new(Arc::new(contribution_projector)))
-			.confirmed(confirmation_blocks_count),
-		Arc::new(ApplicationObserver::new(Arc::new(contribution_service)))
-			.confirmed(confirmation_blocks_count),
+		Arc::new(ContributionObserver::new(Arc::new(contribution_projector))),
+		Arc::new(ApplicationObserver::new(Arc::new(contribution_service))),
+		database,
 	]);
 
 	Arc::new(observer)

--- a/marketplace-indexer/src/main.rs
+++ b/marketplace-indexer/src/main.rs
@@ -15,11 +15,13 @@ fn channel_size() -> usize {
 
 fn get_root_logger() -> Logger {
 	let drain = match std::env::var("LOGS") {
-		Ok(logs) if &logs == "terminal" => slog_async::Async::default(slog_envlogger::new(
+		Ok(logs) if &logs == "terminal" => slog_async::Async::new(slog_envlogger::new(
 			slog_term::CompactFormat::new(slog_term::TermDecorator::new().stderr().build())
 				.build()
 				.fuse(),
-		)),
+		))
+		.chan_size(channel_size())
+		.build(),
 		_ => slog_async::Async::new(slog_envlogger::new(
 			slog_json::Json::new(std::io::stdout()).add_default_keys().build().fuse(),
 		))

--- a/marketplace-indexer/src/main.rs
+++ b/marketplace-indexer/src/main.rs
@@ -85,9 +85,9 @@ fn build_contribution_observers(
 
 	let observer = BlockchainObserverComposite::new(vec![
 		Arc::new(BlockchainLogger::default()),
+		database,
 		Arc::new(ContributionObserver::new(Arc::new(contribution_projector))),
 		Arc::new(ApplicationObserver::new(Arc::new(contribution_service))),
-		database,
 	]);
 
 	Arc::new(observer)

--- a/marketplace-infrastructure/src/database/domain_implementations/event_store.rs
+++ b/marketplace-infrastructure/src/database/domain_implementations/event_store.rs
@@ -1,6 +1,5 @@
 use crate::database::{models, schema::events, Client};
 use diesel::prelude::*;
-use log::info;
 use marketplace_domain::*;
 use serde_json::Value;
 
@@ -12,10 +11,7 @@ impl EventStore<Contribution> for Client {
 		aggregate_id: &<Contribution as Aggregate>::Id,
 		events: Vec<<Contribution as Aggregate>::Event>,
 	) -> Result<(), EventStoreError> {
-		info!("In DB layer with events: {:?}", events);
-
 		let connection = self.connection().map_err(|_| EventStoreError::Connection)?;
-		info!("Connection retrieved from pool");
 
 		let events = events
 			.iter()
@@ -29,14 +25,10 @@ impl EventStore<Contribution> for Client {
 			})
 			.collect::<Result<Vec<_>, EventStoreError>>()?;
 
-		info!("Inserting events in database: {:?}", events);
-
 		diesel::insert_into(events::table)
 			.values(&events)
 			.execute(&*connection)
 			.map_err(|_| EventStoreError::Append)?;
-
-		info!("Insertion OK");
 
 		Ok(())
 	}

--- a/scripts/docker/dev/docker-compose.yml
+++ b/scripts/docker/dev/docker-compose.yml
@@ -1,17 +1,19 @@
 version: '3.8'
 services:
   db:
+    container_name: marketplace-db
     image: postgres:14.3-alpine
     restart: always
     environment:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=postgres
-      - POSTGRES_DB=deathnote_contributions_db
+      - POSTGRES_DB=marketplace_db
     ports:
       - '5432:5432'
     volumes:
       - db:/var/lib/postgresql/data
   pgadmin:
+    container_name: pgadmin
     image: dpage/pgadmin4
     restart: always
     environment:

--- a/scripts/docker/dev/docker-compose.yml
+++ b/scripts/docker/dev/docker-compose.yml
@@ -21,13 +21,6 @@ services:
       PGADMIN_DEFAULT_PASSWORD: postgres
     ports:
       - "5060:80"
-  starknet-devnet:
-    image: shardlabs/starknet-devnet:${BASE_TAG}
-    command: --seed 0 --load-path /tmp/dump.pkl
-    ports:
-      - "5050:5050"
-    volumes:
-      - .:/tmp
 volumes:
   db:
     driver: local


### PR DESCRIPTION
- :bug: add timeout management in github client call to avoid blocking request
- :mute: remove debugging logs
- :bug: increase log channel size in local to avoid losing logs
- :recycle: remove confirmation observer as not needed on StarkNet
- :hammer: rename docker containers and database in local
- :hammer: remove starknet-devnet from docker-compose as not used for now
- :recycle: move event store observer first in the composite
