### PR TITLE
refresh applications route

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -44,7 +44,7 @@ jobs:
           BASE_TAG: latest
 
       - name: Install diesel CLI
-        run: cargo install diesel_cli --no-default-features --features postgres
+        run: cargo install diesel_cli --no-default-features --features postgres --force
 
       - name: Run migrations
         run: diesel migration run

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -118,7 +118,7 @@ jobs:
         env:
           BASE_TAG: latest
       - name: Install diesel CLI
-        run: cargo install diesel_cli --no-default-features --features postgres
+        run: cargo install diesel_cli --no-default-features --features postgres --force
       - name: Build
         run: cargo build
       - name: Run migrations
@@ -152,7 +152,7 @@ jobs:
         env:
           BASE_TAG: latest
       - name: Install diesel CLI
-        run: cargo install diesel_cli --no-default-features --features postgres
+        run: cargo install diesel_cli --no-default-features --features postgres --force
       - name: Build
         run: cargo build
       - name: Run migrations

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1713,6 +1713,7 @@ dependencies = [
 name = "marketplace-domain"
 version = "0.0.1"
 dependencies = [
+ "anyhow",
  "assert-json-diff",
  "assert_matches",
  "async-std",

--- a/marketplace-core/src/application/contribution/mod.rs
+++ b/marketplace-core/src/application/contribution/mod.rs
@@ -27,4 +27,4 @@ mod accept_application;
 pub use accept_application::{AcceptApplication, Usecase as AcceptApplicationUsecase};
 
 mod refresh;
-pub use refresh::RefreshContributions;
+pub use refresh::{RefreshApplications, RefreshContributions};

--- a/marketplace-core/src/application/contribution/mod.rs
+++ b/marketplace-core/src/application/contribution/mod.rs
@@ -27,4 +27,4 @@ mod accept_application;
 pub use accept_application::{AcceptApplication, Usecase as AcceptApplicationUsecase};
 
 mod refresh;
-pub use refresh::{Error as RefreshContributionsError, Refresh as RefreshContributions};
+pub use refresh::RefreshContributions;

--- a/marketplace-core/src/application/contribution/refresh.rs
+++ b/marketplace-core/src/application/contribution/refresh.rs
@@ -55,7 +55,7 @@ mod test {
 
 	#[fixture]
 	fn contributor_id() -> ContributorId {
-		ContributorId::from_str("0x123").unwrap()
+		ContributorId::from_str("0x666").unwrap()
 	}
 
 	#[fixture]
@@ -75,7 +75,7 @@ mod test {
 
 		// events for contribution #1
 		{
-			let contribution_id = ContributionId::from_str("0x01").unwrap();
+			let contribution_id = ContributionId::from_str("0x17267621").unwrap();
 			database
 				.append(
 					&contribution_id,
@@ -107,7 +107,7 @@ mod test {
 
 		// events for contribution #2
 		{
-			let contribution_id = ContributionId::from_str("0x02").unwrap();
+			let contribution_id = ContributionId::from_str("0x17267622").unwrap();
 			database
 				.append(
 					&contribution_id,

--- a/marketplace-core/src/application/contribution/refresh.rs
+++ b/marketplace-core/src/application/contribution/refresh.rs
@@ -6,20 +6,20 @@ use thiserror::Error;
 #[derive(Debug, Error)]
 pub enum Error {
 	#[error(transparent)]
-	ContributionProjectionRepository(#[from] ContributionProjectionRepositoryError),
+	ProjectionRepository(#[from] ProjectionRepositoryError),
 	#[error(transparent)]
 	EventStore(#[from] EventStoreError),
 }
 
 pub struct Refresh {
-	contribution_projection_repository: Arc<dyn ContributionProjectionRepository>,
+	contribution_projection_repository: Arc<dyn ProjectionRepository<Contribution>>,
 	contribution_projector: Arc<dyn Projector<Contribution>>,
 	contribution_event_store: Arc<dyn EventStore<Contribution>>,
 }
 
 impl Refresh {
 	pub fn new(
-		contribution_projection_repository: Arc<dyn ContributionProjectionRepository>,
+		contribution_projection_repository: Arc<dyn ProjectionRepository<Contribution>>,
 		contribution_projector: Arc<dyn Projector<Contribution>>,
 		event_store: Arc<dyn EventStore<Contribution>>,
 	) -> Self {

--- a/marketplace-core/src/application/mod.rs
+++ b/marketplace-core/src/application/mod.rs
@@ -1,2 +1,5 @@
 mod contribution;
 pub use contribution::*;
+
+mod refresh;
+pub use refresh::Error as RefreshError;

--- a/marketplace-core/src/application/refresh.rs
+++ b/marketplace-core/src/application/refresh.rs
@@ -11,13 +11,13 @@ pub enum Error {
 	EventStore(#[from] EventStoreError),
 }
 
-pub struct Refresh<P, A: Aggregate> {
+pub struct Refresh<P: Projection, A: Aggregate> {
 	projection_repository: Arc<dyn ProjectionRepository<P>>,
 	projector: Arc<dyn Projector<A>>,
 	event_store: Arc<dyn EventStore<A>>,
 }
 
-impl<P, A: Aggregate> Refresh<P, A> {
+impl<P: Projection, A: Aggregate> Refresh<P, A> {
 	pub fn new(
 		projection_repository: Arc<dyn ProjectionRepository<P>>,
 		projector: Arc<dyn Projector<A>>,

--- a/marketplace-core/src/application/refresh.rs
+++ b/marketplace-core/src/application/refresh.rs
@@ -1,0 +1,44 @@
+use std::sync::Arc;
+
+use marketplace_domain::*;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum Error {
+	#[error(transparent)]
+	ProjectionRepository(#[from] ProjectionRepositoryError),
+	#[error(transparent)]
+	EventStore(#[from] EventStoreError),
+}
+
+pub struct Refresh<P, A: Aggregate> {
+	projection_repository: Arc<dyn ProjectionRepository<P>>,
+	projector: Arc<dyn Projector<A>>,
+	event_store: Arc<dyn EventStore<A>>,
+}
+
+impl<P, A: Aggregate> Refresh<P, A> {
+	pub fn new(
+		projection_repository: Arc<dyn ProjectionRepository<P>>,
+		projector: Arc<dyn Projector<A>>,
+		event_store: Arc<dyn EventStore<A>>,
+	) -> Self {
+		Self {
+			projection_repository,
+			projector,
+			event_store,
+		}
+	}
+
+	pub async fn refresh_projection_from_events(&self) -> Result<(), Error> {
+		self.projection_repository.clear()?;
+
+		let events = self.event_store.list()?;
+
+		for event in events.iter() {
+			self.projector.project(event).await;
+		}
+
+		Ok(())
+	}
+}

--- a/marketplace-core/src/main.rs
+++ b/marketplace-core/src/main.rs
@@ -97,6 +97,7 @@ async fn main() {
 			routes::unassign_contributor,
 			routes::apply_to_contribution,
 			routes::list_applications,
+			routes::refresh_applications,
 			routes::accept_application,
 			routes::list_contributor_applications,
 			routes::refresh_contributions,
@@ -136,7 +137,7 @@ fn inject_app(
 		.manage(ApplyToContribution::new_usecase_boxed(
 			contribution_repository,
 			database.clone(),
-			application_projector,
+			application_projector.clone(),
 			uuid_generator,
 		))
 		.manage(ValidateContribution::new_usecase_boxed(
@@ -151,6 +152,11 @@ fn inject_app(
 		.manage(RefreshContributions::new(
 			database.clone(),
 			contribution_projector,
+			database.clone(),
+		))
+		.manage(RefreshApplications::new(
+			database.clone(),
+			application_projector,
 			database.clone(),
 		))
 		.manage(database as Arc<dyn ApplicationProjectionRepository>)

--- a/marketplace-core/src/routes/applications/list/tests.rs
+++ b/marketplace-core/src/routes/applications/list/tests.rs
@@ -56,10 +56,6 @@ impl ApplicationProjectionRepository for EmptyDatabase {
 	) -> Result<Vec<ApplicationProjection>, ApplicationProjectionRepositoryError> {
 		Ok(vec![])
 	}
-
-	fn clear(&self) -> Result<(), ApplicationProjectionRepositoryError> {
-		unimplemented!()
-	}
 }
 struct FilledDatabase;
 impl ApplicationProjectionRepository for FilledDatabase {
@@ -151,10 +147,6 @@ impl ApplicationProjectionRepository for FilledDatabase {
 				),
 			]),
 		}
-	}
-
-	fn clear(&self) -> Result<(), ApplicationProjectionRepositoryError> {
-		unimplemented!()
 	}
 }
 

--- a/marketplace-core/src/routes/applications/mod.rs
+++ b/marketplace-core/src/routes/applications/mod.rs
@@ -1,5 +1,7 @@
 mod accept;
 mod list;
+mod refresh;
 
 pub use accept::*;
 pub use list::*;
+pub use refresh::*;

--- a/marketplace-core/src/routes/applications/refresh.rs
+++ b/marketplace-core/src/routes/applications/refresh.rs
@@ -1,0 +1,20 @@
+use crate::{
+	routes::{api_key::ApiKey, to_http_api_problem::ToHttpApiProblem},
+	RefreshApplications,
+};
+use http_api_problem::HttpApiProblem;
+use rocket::{http::Status, State};
+use rocket_okapi::openapi;
+
+#[openapi(tag = "Applications")]
+#[post("/applications/refresh")]
+pub async fn refresh_applications(
+	_api_key: ApiKey,
+	usecase: &State<RefreshApplications>,
+) -> Result<Status, HttpApiProblem> {
+	usecase
+		.refresh_projection_from_events()
+		.await
+		.map_err(|e| e.to_http_api_problem())?;
+	Ok(Status::Ok)
+}

--- a/marketplace-core/src/routes/contributions/applications_list/tests.rs
+++ b/marketplace-core/src/routes/contributions/applications_list/tests.rs
@@ -55,10 +55,6 @@ impl ApplicationProjectionRepository for EmptyDatabase {
 	) -> Result<Vec<ApplicationProjection>, ApplicationProjectionRepositoryError> {
 		unimplemented!()
 	}
-
-	fn clear(&self) -> Result<(), ApplicationProjectionRepositoryError> {
-		unimplemented!()
-	}
 }
 struct FilledDatabase;
 impl ApplicationProjectionRepository for FilledDatabase {
@@ -106,10 +102,6 @@ impl ApplicationProjectionRepository for FilledDatabase {
 		&self,
 		_contributor_id: Option<ContributorId>,
 	) -> Result<Vec<ApplicationProjection>, ApplicationProjectionRepositoryError> {
-		unimplemented!()
-	}
-
-	fn clear(&self) -> Result<(), ApplicationProjectionRepositoryError> {
 		unimplemented!()
 	}
 }

--- a/marketplace-core/src/routes/dto/to_http_api_problem.rs
+++ b/marketplace-core/src/routes/dto/to_http_api_problem.rs
@@ -1,4 +1,4 @@
-use crate::RefreshContributionsError;
+use crate::RefreshError;
 use http_api_problem::{HttpApiProblem, StatusCode};
 use marketplace_domain::{Error as DomainError, *};
 
@@ -117,11 +117,11 @@ impl ToHttpApiProblem for ParseHexPrefixedStringError {
 	}
 }
 
-impl ToHttpApiProblem for RefreshContributionsError {
+impl ToHttpApiProblem for RefreshError {
 	fn to_http_api_problem(&self) -> HttpApiProblem {
 		match self {
-			RefreshContributionsError::ProjectionRepository(error) => error.to_http_api_problem(),
-			RefreshContributionsError::EventStore(error) => error.to_http_api_problem(),
+			RefreshError::ProjectionRepository(error) => error.to_http_api_problem(),
+			RefreshError::EventStore(error) => error.to_http_api_problem(),
 		}
 	}
 }

--- a/marketplace-core/src/routes/dto/to_http_api_problem.rs
+++ b/marketplace-core/src/routes/dto/to_http_api_problem.rs
@@ -120,14 +120,21 @@ impl ToHttpApiProblem for ParseHexPrefixedStringError {
 impl ToHttpApiProblem for RefreshContributionsError {
 	fn to_http_api_problem(&self) -> HttpApiProblem {
 		match self {
-			RefreshContributionsError::ContributionProjectionRepository(error) =>
-				error.to_http_api_problem(),
+			RefreshContributionsError::ProjectionRepository(error) => error.to_http_api_problem(),
 			RefreshContributionsError::EventStore(error) => error.to_http_api_problem(),
 		}
 	}
 }
 
 impl ToHttpApiProblem for EventStoreError {
+	fn to_http_api_problem(&self) -> HttpApiProblem {
+		HttpApiProblem::new(StatusCode::INTERNAL_SERVER_ERROR)
+			.title("Internal error")
+			.detail(self.to_string())
+	}
+}
+
+impl ToHttpApiProblem for ProjectionRepositoryError {
 	fn to_http_api_problem(&self) -> HttpApiProblem {
 		HttpApiProblem::new(StatusCode::INTERNAL_SERVER_ERROR)
 			.title("Internal error")

--- a/marketplace-domain/Cargo.toml
+++ b/marketplace-domain/Cargo.toml
@@ -29,6 +29,7 @@ mapinto = "0.2.1"
 
 # Errors
 thiserror = "1.0.31"
+anyhow = "1.0.57"
 
 # Log
 log = "0.4.17"

--- a/marketplace-domain/src/contribution/projections/application.rs
+++ b/marketplace-domain/src/contribution/projections/application.rs
@@ -38,6 +38,8 @@ pub struct Projection {
 	status: Status,
 }
 
+impl crate::Projection for Projection {}
+
 impl Projection {
 	pub fn new(id: Id, contribution_id: ContributionId, contributor_id: ContributorId) -> Self {
 		Self {

--- a/marketplace-domain/src/contribution/projections/contribution.rs
+++ b/marketplace-domain/src/contribution/projections/contribution.rs
@@ -15,6 +15,8 @@ pub struct Projection {
 	pub metadata: Metadata,
 }
 
+impl crate::Projection for Projection {}
+
 impl Projection {
 	pub fn old_composite_id(&self) -> u64 {
 		let project_id: u64 = self.project_id;

--- a/marketplace-domain/src/contribution/projectors/contribution/contribution_with_github_data_projector.rs
+++ b/marketplace-domain/src/contribution/projectors/contribution/contribution_with_github_data_projector.rs
@@ -112,7 +112,7 @@ impl Projector<Contribution> for WithGithubDataProjector {
 				__self.on_assign(id, contributor_id),
 			ContributionEvent::Unassigned { id } => __self.on_unassign(id),
 			ContributionEvent::Validated { id } => __self.on_validate(id),
-			ContributionEvent::Applied { .. } => todo!(),
+			ContributionEvent::Applied { .. } => Ok(()),
 		};
 
 		if let Err(error) = result {

--- a/marketplace-domain/src/lib.rs
+++ b/marketplace-domain/src/lib.rs
@@ -29,6 +29,9 @@ pub use aggregate::{Aggregate, AggregateRoot};
 mod projector;
 pub use projector::Projector;
 
+mod projection_repository;
+pub use projection_repository::{Error as ProjectionRepositoryError, ProjectionRepository};
+
 mod contribution;
 pub use contribution::{AggregateId as ContributionId, *};
 

--- a/marketplace-domain/src/lib.rs
+++ b/marketplace-domain/src/lib.rs
@@ -29,6 +29,9 @@ pub use aggregate::{Aggregate, AggregateRoot};
 mod projector;
 pub use projector::Projector;
 
+mod projection;
+pub use projection::Projection;
+
 mod projection_repository;
 pub use projection_repository::{Error as ProjectionRepositoryError, ProjectionRepository};
 

--- a/marketplace-domain/src/projection.rs
+++ b/marketplace-domain/src/projection.rs
@@ -1,0 +1,1 @@
+pub trait Projection {}

--- a/marketplace-domain/src/projection_repository.rs
+++ b/marketplace-domain/src/projection_repository.rs
@@ -1,0 +1,11 @@
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum Error {
+	#[error("Something happend at the infrastructure level")]
+	Infrastructure(#[source] anyhow::Error),
+}
+
+pub trait ProjectionRepository<P>: Send + Sync {
+	fn clear(&self) -> Result<(), Error>;
+}

--- a/marketplace-domain/src/projection_repository.rs
+++ b/marketplace-domain/src/projection_repository.rs
@@ -1,3 +1,4 @@
+use crate::Projection;
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -6,6 +7,6 @@ pub enum Error {
 	Infrastructure(#[source] anyhow::Error),
 }
 
-pub trait ProjectionRepository<P>: Send + Sync {
+pub trait ProjectionRepository<P: Projection>: Send + Sync {
 	fn clear(&self) -> Result<(), Error>;
 }

--- a/marketplace-domain/src/repositories/application_projection.rs
+++ b/marketplace-domain/src/repositories/application_projection.rs
@@ -34,5 +34,4 @@ pub trait Repository: Send + Sync {
 		&self,
 		contributor_id: Option<ContributorId>,
 	) -> Result<Vec<ApplicationProjection>, Error>;
-	fn clear(&self) -> Result<(), Error>;
 }

--- a/marketplace-domain/src/repositories/contribution_projection.rs
+++ b/marketplace-domain/src/repositories/contribution_projection.rs
@@ -35,6 +35,4 @@ pub trait Repository: Send + Sync {
 		contribution_id: ContributionId,
 		status: ContributionStatus,
 	) -> Result<(), Error>;
-
-	fn clear(&self) -> Result<(), Error>;
 }

--- a/marketplace-infrastructure/src/database/repositories/application.rs
+++ b/marketplace-infrastructure/src/database/repositories/application.rs
@@ -114,12 +114,19 @@ impl ApplicationProjectionRepository for Client {
 
 		Ok(applications.into_iter().map_into().collect())
 	}
+}
 
-	fn clear(&self) -> Result<(), ApplicationProjectionRepositoryError> {
-		let connection = self.connection().map_err(ApplicationProjectionRepositoryError::from)?;
+impl ProjectionRepository<ApplicationProjection> for Client {
+	fn clear(&self) -> Result<(), ProjectionRepositoryError> {
+		let connection = self
+			.connection()
+			.map_err(anyhow::Error::msg)
+			.map_err(ProjectionRepositoryError::Infrastructure)?;
+
 		diesel::delete(applications::dsl::applications)
 			.execute(&*connection)
-			.map_err(DatabaseError::from)?;
+			.map_err(anyhow::Error::msg)
+			.map_err(ProjectionRepositoryError::Infrastructure)?;
 
 		Ok(())
 	}

--- a/marketplace-infrastructure/src/database/repositories/contribution.rs
+++ b/marketplace-infrastructure/src/database/repositories/contribution.rs
@@ -81,7 +81,7 @@ impl ContributionProjectionRepository for Client {
 	}
 }
 
-impl ProjectionRepository<Contribution> for Client {
+impl ProjectionRepository<ContributionProjection> for Client {
 	fn clear(&self) -> Result<(), ProjectionRepositoryError> {
 		let connection = self
 			.connection()

--- a/marketplace-infrastructure/src/database/repositories/contribution.rs
+++ b/marketplace-infrastructure/src/database/repositories/contribution.rs
@@ -79,12 +79,19 @@ impl ContributionProjectionRepository for Client {
 
 		Ok(())
 	}
+}
 
-	fn clear(&self) -> Result<(), ContributionProjectionRepositoryError> {
-		let connection = self.connection().map_err(ContributionProjectionRepositoryError::from)?;
+impl ProjectionRepository<Contribution> for Client {
+	fn clear(&self) -> Result<(), ProjectionRepositoryError> {
+		let connection = self
+			.connection()
+			.map_err(anyhow::Error::msg)
+			.map_err(ProjectionRepositoryError::Infrastructure)?;
+
 		diesel::delete(schema::contributions::dsl::contributions)
 			.execute(&*connection)
-			.map_err(DatabaseError::from)?;
+			.map_err(anyhow::Error::msg)
+			.map_err(ProjectionRepositoryError::Infrastructure)?;
 
 		Ok(())
 	}

--- a/marketplace-infrastructure/src/database/tests/application_repository.rs
+++ b/marketplace-infrastructure/src/database/tests/application_repository.rs
@@ -100,25 +100,6 @@ fn cannot_apply_twice() {
 	not(feature = "with_infrastructure_tests"),
 	ignore = "infrastructure test"
 )]
-fn contribution_id_must_exist() {
-	let client = Client::new(init_pool());
-
-	let application = ApplicationProjection::new(Uuid::new_v4().into(), 1.into(), 0.into());
-
-	let res = <Client as ApplicationProjectionRepository>::create(&client, application);
-
-	assert!(res.is_err());
-	assert_matches!(
-		res.unwrap_err(),
-		ApplicationProjectionRepositoryError::InvalidEntity(_)
-	);
-}
-
-#[test]
-#[cfg_attr(
-	not(feature = "with_infrastructure_tests"),
-	ignore = "infrastructure test"
-)]
 fn store_multiple_and_list() {
 	let client = Client::new(init_pool());
 


### PR DESCRIPTION
- :recycle: extract clear function into a common trait
- :recycle: extract refresh usecase as a generic implementation
- :sparkles: implement refresh applications usecase
- :sparkles: expose route to refresh applications
