### PR TITLE
decorelate indexer creations from events listeners to prepare for dynamic indexing

### DIFF
--- a/marketplace-indexer/src/application/builders/indexer.rs
+++ b/marketplace-indexer/src/application/builders/indexer.rs
@@ -101,6 +101,7 @@ impl Builder {
 #[cfg(test)]
 mod tests {
 	use super::*;
+	use anyhow::anyhow;
 	use mockall::predicate::*;
 	use rstest::*;
 	use std::str::FromStr;
@@ -243,7 +244,7 @@ mod tests {
 			.returning(|_| {
 				Err(IndexerRepositoryError::GetIndexer {
 					id: "ID".into(),
-					details: String::new(),
+					source: anyhow!("oops"),
 				})
 			});
 
@@ -262,7 +263,7 @@ mod tests {
 		indexer_repository.expect_create().returning(|_| {
 			Err(IndexerRepositoryError::CreateIndexer {
 				id: "ID".into(),
-				details: String::new(),
+				source: anyhow!("oops"),
 			})
 		});
 
@@ -288,7 +289,7 @@ mod tests {
 		indexer_repository.expect_delete().returning(|_| {
 			Err(IndexerRepositoryError::DeleteIndexer {
 				id: "ID".into(),
-				details: String::new(),
+				source: anyhow!("oops"),
 			})
 		});
 

--- a/marketplace-indexer/src/application/indexing.rs
+++ b/marketplace-indexer/src/application/indexing.rs
@@ -1,0 +1,119 @@
+use crate::domain::*;
+use futures::future::try_join_all;
+use std::sync::Arc;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum Error {
+	#[error(transparent)]
+	Repository(#[from] IndexerRepositoryError),
+	#[error(transparent)]
+	Service(#[from] IndexingServiceError),
+}
+
+pub struct Usecase {
+	indexer_repository: Arc<dyn IndexerRepository>,
+	indexing_service: Arc<dyn IndexingService>,
+	observer: Arc<dyn BlockchainObserver>,
+}
+
+impl Usecase {
+	pub fn new(
+		indexer_repository: Arc<dyn IndexerRepository>,
+		indexing_service: Arc<dyn IndexingService>,
+		observer: Arc<dyn BlockchainObserver>,
+	) -> Self {
+		Self {
+			indexer_repository,
+			indexing_service,
+			observer,
+		}
+	}
+
+	pub async fn run_all_indexers(&self) -> Result<(), Error> {
+		let indexers = self.indexer_repository.list().await?;
+
+		try_join_all(
+			indexers.into_iter().map(|indexer| {
+				self.indexing_service.fetch_new_events(indexer, self.observer.clone())
+			}),
+		)
+		.await?;
+
+		Ok(())
+	}
+}
+
+#[cfg(test)]
+mod test {
+	use super::*;
+	use mockall::predicate::*;
+	use rstest::*;
+
+	#[fixture]
+	fn indexer_ids() -> Vec<IndexerId> {
+		vec![
+			String::from("indexer-1").into(),
+			String::from("indexer-2").into(),
+			String::from("indexer-3").into(),
+		]
+	}
+
+	#[fixture]
+	fn indexers(indexer_ids: Vec<IndexerId>) -> Vec<Indexer> {
+		indexer_ids
+			.into_iter()
+			.map(|id| Indexer {
+				id,
+				..Default::default()
+			})
+			.collect()
+	}
+
+	#[fixture]
+	fn indexer_repository() -> MockIndexerRepository {
+		MockIndexerRepository::new()
+	}
+
+	#[fixture]
+	fn indexing_service() -> MockIndexingService {
+		MockIndexingService::new()
+	}
+
+	#[fixture]
+	fn observer() -> MockBlockchainObserver {
+		MockBlockchainObserver::new()
+	}
+
+	#[fixture]
+	fn blockchain_observer() -> MockBlockchainObserver {
+		MockBlockchainObserver::new()
+	}
+
+	#[rstest]
+	async fn run_all_indexers(
+		mut indexer_repository: MockIndexerRepository,
+		mut indexing_service: MockIndexingService,
+		indexers: Vec<Indexer>,
+	) {
+		let cloned_indexers = indexers.clone();
+		indexer_repository.expect_list().times(1).return_once(|| Ok(cloned_indexers));
+
+		for indexer in indexers {
+			indexing_service
+				.expect_fetch_new_events()
+				.times(1)
+				.with(eq(indexer), always())
+				.returning(|_, _| Ok(()));
+		}
+
+		let usecase = Usecase::new(
+			Arc::new(indexer_repository),
+			Arc::new(indexing_service),
+			Arc::new(MockBlockchainObserver::new()),
+		);
+
+		let result = usecase.run_all_indexers().await;
+		assert!(result.is_ok(), "{}", result.err().unwrap());
+	}
+}

--- a/marketplace-indexer/src/application/mod.rs
+++ b/marketplace-indexer/src/application/mod.rs
@@ -1,2 +1,5 @@
 mod builders;
 pub use builders::*;
+
+mod indexing;
+pub use indexing::Usecase as IndexingUsecase;

--- a/marketplace-indexer/src/domain/repositories/indexer.rs
+++ b/marketplace-indexer/src/domain/repositories/indexer.rs
@@ -15,6 +15,8 @@ pub enum Error {
 		id: IndexerId,
 		source: anyhow::Error,
 	},
+	#[error("Failed while listing indexers")]
+	ListIndexers(#[source] anyhow::Error),
 	#[error("Failed while deleting indexer `{id}`: {source}")]
 	DeleteIndexer {
 		id: IndexerId,
@@ -29,5 +31,6 @@ type Result<T> = std::result::Result<T, Error>;
 pub trait Repository {
 	async fn create(&self, indexer: &Indexer) -> Result<()>;
 	async fn by_id(&self, indexer_id: &IndexerId) -> Result<Option<Indexer>>;
+	async fn list(&self) -> Result<Vec<Indexer>>;
 	async fn delete(&self, indexer_id: &IndexerId) -> Result<()>;
 }

--- a/marketplace-indexer/src/domain/repositories/indexer.rs
+++ b/marketplace-indexer/src/domain/repositories/indexer.rs
@@ -1,18 +1,25 @@
 use crate::domain::*;
 use async_trait::async_trait;
 use mockall::automock;
-use thiserror::Error as ThisError;
+use thiserror::Error;
 
-#[derive(ThisError, Debug)]
+#[derive(Error, Debug)]
 pub enum Error {
-	#[error("unable to connect to the indexing service")]
-	Connection(#[from] Box<dyn std::error::Error>),
-	#[error("unable to create the indexer `{id}`: {details}")]
-	CreateIndexer { id: IndexerId, details: String },
-	#[error("unable to get the indexer `{id}`: {details}")]
-	GetIndexer { id: IndexerId, details: String },
-	#[error("unable to delete the indexer `{id}`: {details}")]
-	DeleteIndexer { id: IndexerId, details: String },
+	#[error("Failed while creating indexer `{id}`: {source}")]
+	CreateIndexer {
+		id: IndexerId,
+		source: anyhow::Error,
+	},
+	#[error("Failed while getting indexer `{id}`: {source}")]
+	GetIndexer {
+		id: IndexerId,
+		source: anyhow::Error,
+	},
+	#[error("Failed while deleting indexer `{id}`: {source}")]
+	DeleteIndexer {
+		id: IndexerId,
+		source: anyhow::Error,
+	},
 }
 
 type Result<T> = std::result::Result<T, Error>;
@@ -23,18 +30,4 @@ pub trait Repository {
 	async fn create(&self, indexer: &Indexer) -> Result<()>;
 	async fn by_id(&self, indexer_id: &IndexerId) -> Result<Option<Indexer>>;
 	async fn delete(&self, indexer_id: &IndexerId) -> Result<()>;
-}
-
-#[cfg(test)]
-mod test {
-	use super::*;
-	use rstest::*;
-
-	#[rstest]
-	#[case(Error::CreateIndexer{id: IndexerId::from("ID"), details: String::from("details")}, "unable to create the indexer `ID`: details")]
-	#[case(Error::GetIndexer{id: IndexerId::from("ID"), details: String::from("details")}, "unable to get the indexer `ID`: details")]
-	#[case(Error::DeleteIndexer{id: IndexerId::from("ID"), details: String::from("details")}, "unable to delete the indexer `ID`: details")]
-	fn error_messages_are_well_formatted(#[case] error: Error, #[case] expected_message: &str) {
-		assert_eq!(expected_message, error.to_string());
-	}
 }

--- a/marketplace-indexer/src/domain/services/indexing.rs
+++ b/marketplace-indexer/src/domain/services/indexing.rs
@@ -22,7 +22,7 @@ type Result<T> = std::result::Result<T, Error>;
 pub trait Service {
 	async fn fetch_new_events(
 		&self,
-		indexer: &Indexer,
+		indexer: Indexer,
 		observers: Arc<dyn BlockchainObserver>,
 	) -> Result<()>;
 }

--- a/marketplace-indexer/src/domain/services/indexing.rs
+++ b/marketplace-indexer/src/domain/services/indexing.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use crate::domain::*;
 use async_trait::async_trait;
+#[cfg(test)]
 use mockall::automock;
 use thiserror::Error as ThisError;
 
@@ -17,7 +18,7 @@ pub enum Error {
 
 type Result<T> = std::result::Result<T, Error>;
 
-#[automock]
+#[cfg_attr(test, automock)]
 #[async_trait]
 pub trait Service {
 	async fn fetch_new_events(

--- a/marketplace-indexer/src/domain/services/mod.rs
+++ b/marketplace-indexer/src/domain/services/mod.rs
@@ -1,2 +1,5 @@
 mod indexing;
 pub use indexing::{Error as IndexingServiceError, Service as IndexingService};
+
+#[cfg(test)]
+pub use indexing::MockService as MockIndexingService;

--- a/marketplace-indexer/src/infrastructure/apibara/indexer_repository.rs
+++ b/marketplace-indexer/src/infrastructure/apibara/indexer_repository.rs
@@ -3,6 +3,7 @@ use super::{
 	Client,
 };
 use crate::domain::*;
+use anyhow::anyhow;
 use async_trait::async_trait;
 use itertools::Itertools;
 
@@ -25,7 +26,7 @@ impl IndexerRepository for Client {
 			.await
 			.map_err(|status| IndexerRepositoryError::CreateIndexer {
 				id: indexer.id.clone(),
-				details: status.to_string(),
+				source: anyhow!(status),
 			})?;
 
 		response
@@ -33,7 +34,7 @@ impl IndexerRepository for Client {
 			.indexer
 			.ok_or_else(|| IndexerRepositoryError::CreateIndexer {
 				id: indexer.id.clone(),
-				details: String::from("Indexer not created"),
+				source: anyhow!("Indexer not created"),
 			})?;
 
 		Ok(())
@@ -53,7 +54,7 @@ impl IndexerRepository for Client {
 			.await
 			.map_err(|status| IndexerRepositoryError::GetIndexer {
 				id: indexer_id.clone(),
-				details: status.to_string(),
+				source: anyhow!(status),
 			})?;
 
 		Ok(response.into_inner().indexer.map(Indexer::from))
@@ -69,7 +70,7 @@ impl IndexerRepository for Client {
 			.await
 			.map_err(|status| IndexerRepositoryError::DeleteIndexer {
 				id: indexer_id.clone(),
-				details: status.to_string(),
+				source: anyhow!(status),
 			})?;
 
 		Ok(())

--- a/marketplace-indexer/src/infrastructure/apibara/indexer_repository.rs
+++ b/marketplace-indexer/src/infrastructure/apibara/indexer_repository.rs
@@ -1,5 +1,7 @@
 use super::{
-	apibara::{self, CreateIndexerRequest, DeleteIndexerRequest, GetIndexerRequest},
+	apibara::{
+		self, CreateIndexerRequest, DeleteIndexerRequest, GetIndexerRequest, ListIndexerRequest,
+	},
 	Client,
 };
 use crate::domain::*;
@@ -58,6 +60,18 @@ impl IndexerRepository for Client {
 			})?;
 
 		Ok(response.into_inner().indexer.map(Indexer::from))
+	}
+
+	async fn list(&self) -> Result<Vec<Indexer>, IndexerRepositoryError> {
+		let response = self
+			.0
+			.write()
+			.await
+			.list_indexer(ListIndexerRequest {})
+			.await
+			.map_err(|status| IndexerRepositoryError::ListIndexers(anyhow!(status)))?;
+
+		Ok(response.into_inner().indexers.into_iter().map_into().collect())
 	}
 
 	async fn delete(&self, indexer_id: &IndexerId) -> Result<(), IndexerRepositoryError> {

--- a/marketplace-indexer/src/infrastructure/apibara/indexing_service/mod.rs
+++ b/marketplace-indexer/src/infrastructure/apibara/indexing_service/mod.rs
@@ -21,7 +21,7 @@ use crate::domain::*;
 impl IndexingService for Client {
 	async fn fetch_new_events(
 		&self,
-		indexer: &Indexer,
+		indexer: Indexer,
 		observer: Arc<dyn BlockchainObserver>,
 	) -> Result<(), IndexingServiceError> {
 		let channel = Channel::new();


### PR DESCRIPTION
- ♻️ refactor error management in indexer
- ✨ add indexer listing in repository
- ♻️ refactor indexer main file
- ♻️ fetch events from all indexers in parallel
