### PR TITLE
use latest smart contract dump to use deployed contract transactions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
 export DATABASE_URL=postgres://postgres:postgres@localhost/marketplace_db                       # URL to the database
 export NETWORK=alpha-goerli                                                                     # devnet or alpha-goerli
-export APIBARA_NODE_URL="https://goerli.starknet.stream.apibara.com"                            # gRPC endpoint of the apibara node
+#export APIBARA_NODE_URL="https://goerli.starknet.stream.apibara.com"                            # gRPC endpoint of the apibara node
+export APIBARA_NODE_URL="http://localhost:7171"                                                 # local gRPC endpoint of the apibara node
 export API_KEY=ROOT
 export API_URL="http://localhost:8000"
 export SLOG_CHANNEL_SIZE=1024
@@ -11,7 +12,7 @@ export RUST_LOG=info
 export ARM_TAG=    # use ARM_TAG="-arm" tag for MacOS
 
 # starknet-devnet deployed contracts
-export CONTRIBUTIONS_ADDRESS=0x000b061238977bb1bd59c2c81bc5670fc2dfbac3854b7a25d9010dffb823b87f
+export CONTRIBUTIONS_ADDRESS=0x03f0e236a4cb1b20278ad5a7e790b29c6e5bac25c34fc3fb0c092f8e5275b512
 
 # Signup
 # Some default values to be able to start the application locally.

--- a/.github/actions/coverage-checks/action.yml
+++ b/.github/actions/coverage-checks/action.yml
@@ -29,7 +29,7 @@ runs:
         DATABASE_URL: postgres://postgres:postgres@localhost/marketplace_db
         GITHUB_ID: githubid
         GITHUB_SECRET: githubsecret
-        CONTRIBUTIONS_ADDRESS: "0x000b061238977bb1bd59c2c81bc5670fc2dfbac3854b7a25d9010dffb823b87f"
+        CONTRIBUTIONS_ADDRESS: "0x03f0e236a4cb1b20278ad5a7e790b29c6e5bac25c34fc3fb0c092f8e5275b512"
         NETWORK: alpha-goerli
         APIBARA_NODE_URL: http://localhost:7171
         API_URL: http://localhost:8000

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,7 +167,7 @@ jobs:
           DATABASE_URL: postgres://postgres:postgres@localhost/marketplace_db
           GITHUB_ID: githubid
           GITHUB_SECRET: githubsecret
-          CONTRIBUTIONS_ADDRESS: "0x000b061238977bb1bd59c2c81bc5670fc2dfbac3854b7a25d9010dffb823b87f"
+          CONTRIBUTIONS_ADDRESS: "0x03f0e236a4cb1b20278ad5a7e790b29c6e5bac25c34fc3fb0c092f8e5275b512"
           NETWORK: alpha-goerli
           APIBARA_NODE_URL: http://localhost:7171
           API_URL: http://localhost:8000

--- a/marketplace-tests/src/e2e_tests/contributions/delete.rs
+++ b/marketplace-tests/src/e2e_tests/contributions/delete.rs
@@ -1,6 +1,6 @@
 use crate::e2e_tests::starknet::{Account, ContractAdministrator, ContributionsContract};
 
-pub async fn delete(account: &Account, contribution_id: u64) {
+pub async fn delete(account: &Account, contribution_id: &str) {
 	let contributions_contract = ContractAdministrator::new(account);
 	contributions_contract
 		.delete_contribution(contribution_id)

--- a/marketplace-tests/src/e2e_tests/scenario/contribution_lifetime.rs
+++ b/marketplace-tests/src/e2e_tests/scenario/contribution_lifetime.rs
@@ -30,7 +30,7 @@ async fn contribution_lifetime(
 	add_lead_contributor(&accounts[0], STARKONQUEST_ID, lead_contributor.address()).await;
 	// Create a new contribution
 	contributions::create(lead_contributor, STARKONQUEST_ID, issue_number, 0).await;
-	wait_for_events(events_count + 2).await;
+	wait_for_events(events_count + 3).await;
 
 	let contribution =
 		contributions::get_project_contribution_by_issue_number(STARKONQUEST_TITLE, issue_number)

--- a/marketplace-tests/src/e2e_tests/scenario/delete_contribution.rs
+++ b/marketplace-tests/src/e2e_tests/scenario/delete_contribution.rs
@@ -5,7 +5,7 @@ use crate::e2e_tests::{
 	contributions,
 	database::events_count,
 	projects::add_lead_contributor,
-	scenario::{hex_str_to_u64, STARKONQUEST_TITLE},
+	scenario::STARKONQUEST_TITLE,
 	starknet::{accounts::accounts, Account},
 };
 use marketplace_core::dto::Application;
@@ -50,7 +50,7 @@ async fn delete_contribution(
 		contribution.id,
 		contributor_id
 	);
-	contributions::delete(lead_contributor, hex_str_to_u64(&contribution.id)).await;
+	contributions::delete(lead_contributor, &contribution.id).await;
 	wait_for_events(events_count + 4).await;
 
 	let contribution =

--- a/marketplace-tests/src/e2e_tests/scenario/delete_contribution.rs
+++ b/marketplace-tests/src/e2e_tests/scenario/delete_contribution.rs
@@ -31,7 +31,7 @@ async fn delete_contribution(
 
 	add_lead_contributor(&accounts[0], STARKONQUEST_ID, lead_contributor.address()).await;
 	contributions::create(lead_contributor, STARKONQUEST_ID, issue_number, 0).await;
-	wait_for_events(events_count + 2).await;
+	wait_for_events(events_count + 3).await;
 
 	let contribution =
 		contributions::get_project_contribution_by_issue_number(STARKONQUEST_TITLE, issue_number)
@@ -51,7 +51,7 @@ async fn delete_contribution(
 		contributor_id
 	);
 	contributions::delete(lead_contributor, &contribution.id).await;
-	wait_for_events(events_count + 4).await;
+	wait_for_events(events_count + 5).await;
 
 	let contribution =
 		contributions::get_project_contribution_by_issue_number(STARKONQUEST_TITLE, issue_number)

--- a/marketplace-tests/src/e2e_tests/scenario/mod.rs
+++ b/marketplace-tests/src/e2e_tests/scenario/mod.rs
@@ -23,7 +23,3 @@ async fn wait_for_events(expected_events_count: i64) {
 
 const STARKONQUEST_ID: u64 = 481932781;
 const STARKONQUEST_TITLE: &str = "starkonquest";
-
-fn hex_str_to_u64(hex: &str) -> u64 {
-	u64::from_str_radix(hex.trim_start_matches("0x"), 16).unwrap()
-}

--- a/marketplace-tests/src/e2e_tests/starknet/contributions.rs
+++ b/marketplace-tests/src/e2e_tests/starknet/contributions.rs
@@ -15,7 +15,7 @@ pub trait ContributionsContract {
 	) -> Result<()>;
 
 	async fn new_contribution(&self, project_id: u64, issue_number: u64, gate: u64) -> Result<()>;
-	async fn delete_contribution(&self, contribution_id: u64) -> Result<()>;
+	async fn delete_contribution(&self, contribution_id: &str) -> Result<()>;
 }
 
 #[async_trait]
@@ -53,12 +53,12 @@ impl<'a> ContributionsContract for ContractAdministrator<'a> {
 		Ok(())
 	}
 
-	async fn delete_contribution(&self, contribution_id: u64) -> Result<()> {
+	async fn delete_contribution(&self, contribution_id: &str) -> Result<()> {
 		self.send_transaction(&[Call {
 			to: FieldElement::from_hex_be(CONTRIBUTIONS_ADDRESS)
 				.expect("Invalid CONTRIBUTIONS_ADDRESS"),
 			selector: get_selector_from_name("delete_contribution").expect("Invalid selector"),
-			calldata: vec![FieldElement::from(contribution_id)],
+			calldata: vec![FieldElement::from_hex_be(contribution_id).unwrap()],
 		}])
 		.await?;
 

--- a/marketplace-tests/src/e2e_tests/starknet/contributions.rs
+++ b/marketplace-tests/src/e2e_tests/starknet/contributions.rs
@@ -4,7 +4,7 @@ use starknet::core::utils::get_selector_from_name;
 
 // From starknet-devnet dump creation
 const CONTRIBUTIONS_ADDRESS: &str =
-	"0x000b061238977bb1bd59c2c81bc5670fc2dfbac3854b7a25d9010dffb823b87f";
+	"0x03f0e236a4cb1b20278ad5a7e790b29c6e5bac25c34fc3fb0c092f8e5275b512";
 
 #[async_trait]
 pub trait ContributionsContract {


### PR DESCRIPTION
- ♻️ use string to represent contribution id as it is now a contract address
- ⬆️ use latest smart contract dump with new contribution API
