### PR TITLE
🐛 fetch contributor from account instead of id

### DIFF
--- a/marketplace-core/src/application/contributor/refresh/test.rs
+++ b/marketplace-core/src/application/contributor/refresh/test.rs
@@ -101,7 +101,6 @@ async fn refresh_contributors_from_events(
 	filled_database: Arc<DatabaseClient>,
 	mut github_client: MockGithubClient,
 	contributor_account_address: ContributorAccountAddress,
-	contributor_id: ContributorAccountAddress,
 ) {
 	let refresh_contributors_usecase: RefreshContributors = {
 		github_client.expect_find_user_by_id().returning(|_| Ok(Default::default()));
@@ -119,13 +118,15 @@ async fn refresh_contributors_from_events(
 	let result = refresh_contributors_usecase.refresh_projection_from_events().await;
 	assert!(result.is_ok(), "{}", result.err().unwrap());
 
-	let result =
-		ContributorProjectionRepository::find_by_id(&*filled_database.clone(), &contributor_id);
+	let result = ContributorProjectionRepository::find_by_account_address(
+		&*filled_database.clone(),
+		&contributor_account_address,
+	);
 	assert!(result.is_ok(), "{}", result.err().unwrap());
 
 	assert_eq!(
 		ContributorProfile {
-			id: contributor_id,
+			id: contributor_account_address.clone(),
 			github_identifier: 100u64,
 			account: contributor_account_address,
 			..Default::default()

--- a/marketplace-core/src/routes/contributors/list.rs
+++ b/marketplace-core/src/routes/contributors/list.rs
@@ -19,7 +19,7 @@ pub async fn get_contributor(
 	let contributor_id = contributor_id.into();
 
 	let contributor = contributor_repository
-		.find_by_id(&contributor_id)
+		.find_by_account_address(&contributor_id)
 		.map_err(|e| e.to_http_api_problem())?;
 
 	Ok(Json(contributor.into()))

--- a/marketplace-core/src/routes/projects/list.rs
+++ b/marketplace-core/src/routes/projects/list.rs
@@ -92,10 +92,10 @@ fn build_contribution(
 	contribution: ContributionProjection,
 	contributor_projection_repository: &Arc<dyn ContributorProjectionRepository>,
 ) -> Option<dto::Contribution> {
-	let contributor = contribution
-		.contributor_account_address
-		.clone()
-		.and_then(|id| contributor_projection_repository.find_by_id(&id).ok());
+	let contributor =
+		contribution.contributor_account_address.clone().and_then(|account_address| {
+			contributor_projection_repository.find_by_account_address(&account_address).ok()
+		});
 
 	let mut contribution = dto::Contribution::from(contribution);
 	contribution.metadata.github_username = contributor.map(|c| c.github_username);

--- a/marketplace-domain/src/repositories/contributor_projection.rs
+++ b/marketplace-domain/src/repositories/contributor_projection.rs
@@ -18,10 +18,6 @@ pub enum Error {
 #[cfg_attr(test, automock)]
 pub trait Repository: Send + Sync {
 	fn insert(&self, contributor: ContributorProfile) -> Result<(), Error>;
-	fn find_by_id(
-		&self,
-		contributor_id: &ContributorAccountAddress,
-	) -> Result<ContributorProfile, Error>;
 	fn find_by_account_address(
 		&self,
 		contributor_account_address: &ContributorAccountAddress,

--- a/marketplace-infrastructure/src/database/repositories/contributor.rs
+++ b/marketplace-infrastructure/src/database/repositories/contributor.rs
@@ -24,20 +24,6 @@ impl ContributorProjectionRepository for Client {
 		Ok(())
 	}
 
-	fn find_by_id(
-		&self,
-		contributor_id: &ContributorAccountAddress,
-	) -> Result<ContributorProfile, ContributorProjectionRepositoryError> {
-		let connection = self.connection().map_err(ContributorProjectionRepositoryError::from)?;
-
-		let contributor: models::Contributor = dsl::contributors
-			.find(contributor_id.to_string())
-			.get_result(&*connection)
-			.map_err(DatabaseError::from)?;
-
-		Ok(contributor.into())
-	}
-
 	fn find_by_account_address(
 		&self,
 		contributor_account_address: &ContributorAccountAddress,


### PR DESCRIPTION
As now the `contributor_account_address` column in `contributions` projection is used to references the contributor assigned, 
we need to fetch the contributor details from `contributors` projection `account` column instead of `id`.

e2e tests will be added in PR #268
https://github.com/onlydustxyz/marketplace-backend/pull/268/files#diff-2844ce2792781d70948ec9885d84e59f6e20fa1435ba0bf380d7969900423e91
