### PR TITLE
improve event bus implementation

### DIFF
--- a/marketplace-core/src/event_listeners/mod.rs
+++ b/marketplace-core/src/event_listeners/mod.rs
@@ -30,17 +30,20 @@ async fn spawn_listeners() -> Result<Vec<JoinHandle<()>>> {
 	let reqwest_client = reqwest::Client::new();
 
 	let handles = [
-		logger::spawn(event_bus::consumer().await?),
-		ProjectMemberProjector::new(database.clone()).spawn(event_bus::consumer().await?),
+		logger::spawn(event_bus::consumer("logger").await?),
+		ProjectMemberProjector::new(database.clone())
+			.spawn(event_bus::consumer("project-member-projector").await?),
 		GithubContributionProjector::new(database.clone(), github.clone())
-			.spawn(event_bus::consumer().await?),
-		ApplicationProjector::new(database.clone()).spawn(event_bus::consumer().await?),
+			.spawn(event_bus::consumer("github-contribution-projector").await?),
+		ApplicationProjector::new(database.clone())
+			.spawn(event_bus::consumer("application-projector").await?),
 		GithubProjectProjector::new(github.clone(), database.clone())
-			.spawn(event_bus::consumer().await?),
+			.spawn(event_bus::consumer("github-project-projector").await?),
 		ContributorWithGithubDataProjector::new(github, database.clone())
-			.spawn(event_bus::consumer().await?),
-		LeadContributorProjector::new(database.clone()).spawn(event_bus::consumer().await?),
-		EventWebHook::new(reqwest_client).spawn(event_bus::consumer().await?),
+			.spawn(event_bus::consumer("github-contributor-projector").await?),
+		LeadContributorProjector::new(database.clone())
+			.spawn(event_bus::consumer("project-lead-projector").await?),
+		EventWebHook::new(reqwest_client).spawn(event_bus::consumer("event-webhooks").await?),
 	];
 
 	Ok(handles.into())

--- a/marketplace-core/src/event_listeners/mod.rs
+++ b/marketplace-core/src/event_listeners/mod.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use futures::future::join_all;
+use futures::future::try_join_all;
 use marketplace_domain::{
 	ApplicationProjector, ContributorWithGithubDataProjector, EventListener,
 	GithubContributionProjector, GithubProjectProjector, LeadContributorProjector,
@@ -19,10 +19,7 @@ mod logger;
 mod projector;
 
 pub async fn main() -> Result<()> {
-	join_all(spawn_listeners().await?)
-		.await
-		.into_iter()
-		.collect::<Result<Vec<()>, _>>()?;
+	try_join_all(spawn_listeners().await?).await?;
 
 	Ok(())
 }

--- a/marketplace-domain/src/messaging/destination.rs
+++ b/marketplace-domain/src/messaging/destination.rs
@@ -1,7 +1,7 @@
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Destination {
 	Queue(String),
-	Exchange { name: String, topic: String },
+	Exchange(String),
 }
 
 impl Destination {
@@ -9,11 +9,8 @@ impl Destination {
 		Self::Queue(name.into())
 	}
 
-	pub fn exchange(name: &str, topic: &str) -> Self {
-		Self::Exchange {
-			name: name.into(),
-			topic: topic.into(),
-		}
+	pub fn exchange(name: &str) -> Self {
+		Self::Exchange(name.into())
 	}
 }
 
@@ -32,11 +29,8 @@ mod tests {
 	#[test]
 	fn create_exchange_destination() {
 		assert_eq!(
-			Destination::exchange("name", "topic"),
-			Destination::Exchange {
-				name: String::from("name"),
-				topic: String::from("topic")
-			}
+			Destination::exchange("name"),
+			Destination::Exchange(String::from("name"))
 		);
 	}
 }

--- a/marketplace-event-store/src/lib.rs
+++ b/marketplace-event-store/src/lib.rs
@@ -44,9 +44,7 @@ async fn store(store: Arc<dyn EventStore>, event: Event) -> Result<Event> {
 }
 
 async fn publish(event: Event, publisher: Arc<dyn Publisher<DomainEvent>>) -> Result<()> {
-	publisher
-		.publish(Destination::exchange(EXCHANGE_NAME, ""), &event.event)
-		.await?;
+	publisher.publish(Destination::exchange(EXCHANGE_NAME), &event.event).await?;
 	Ok(())
 }
 

--- a/marketplace-infrastructure/src/amqp/bus.rs
+++ b/marketplace-infrastructure/src/amqp/bus.rs
@@ -1,6 +1,8 @@
 use lapin::{
-	message::Delivery, options::QueueDeclareOptions, publisher_confirm::Confirmation, Channel,
-	Connection, Consumer,
+	message::Delivery,
+	options::{ExchangeDeclareOptions, QueueDeclareOptions},
+	publisher_confirm::Confirmation,
+	Channel, Connection, Consumer,
 };
 use log::error;
 use thiserror::Error;
@@ -92,7 +94,10 @@ impl ConsumableBus {
 			.exchange_declare(
 				exchange_name,
 				lapin::ExchangeKind::Fanout,
-				Default::default(),
+				ExchangeDeclareOptions {
+					durable: true,
+					..Default::default()
+				},
 				Default::default(),
 			)
 			.await?;

--- a/marketplace-infrastructure/src/amqp/publisher.rs
+++ b/marketplace-infrastructure/src/amqp/publisher.rs
@@ -8,7 +8,7 @@ impl<M: Message + Send + Sync> Publisher<M> for Bus {
 	async fn publish(&self, destination: Destination, message: &M) -> Result<(), PublisherError> {
 		let (exchange_name, routing_key) = match destination {
 			Destination::Queue(name) => (String::new(), name),
-			Destination::Exchange { name, topic } => (name, topic),
+			Destination::Exchange(name) => (name, String::new()),
 		};
 
 		let confirmation = self

--- a/marketplace-infrastructure/src/event_bus.rs
+++ b/marketplace-infrastructure/src/event_bus.rs
@@ -10,7 +10,9 @@ pub async fn consumer() -> Result<ConsumableBus, BusError> {
 		.with_queue(
 			"",
 			QueueDeclareOptions {
-				exclusive: true, // only one consumer on this queue
+				exclusive: true,    // only one consumer on this queue
+				durable: true,      // persist messages
+				auto_delete: false, // keep the queue during consumer restart
 				..Default::default()
 			},
 		)

--- a/marketplace-infrastructure/src/event_bus.rs
+++ b/marketplace-infrastructure/src/event_bus.rs
@@ -4,11 +4,11 @@ use log::info;
 
 pub const EXCHANGE_NAME: &str = "events";
 
-pub async fn consumer() -> Result<ConsumableBus, BusError> {
+pub async fn consumer(queue_name: &'static str) -> Result<ConsumableBus, BusError> {
 	let bus = Bus::default()
 		.await?
 		.with_queue(
-			"",
+			queue_name,
 			QueueDeclareOptions {
 				exclusive: true,    // only one consumer on this queue
 				durable: true,      // persist messages
@@ -20,6 +20,6 @@ pub async fn consumer() -> Result<ConsumableBus, BusError> {
 		.with_exchange(EXCHANGE_NAME)
 		.await?;
 
-	info!("[events] 🎧 Start listening to events");
+	info!("[{queue_name}] 🎧 Start listening to events");
 	Ok(bus)
 }


### PR DESCRIPTION
- ⚰️ remove unused routing key from destination
- 🔒️ make process panic when at least one listener crashed
- 🐛 make queues and exchanges durable
- ♻️ better naming for consumer queues
