### PR TITLE
create mutation for emitting an event upon payment processed

### DIFF
--- a/marketplace-core/src/application/mod.rs
+++ b/marketplace-core/src/application/mod.rs
@@ -9,3 +9,5 @@ pub use project::*;
 
 mod contributor;
 pub use contributor::*;
+
+pub mod payment;

--- a/marketplace-core/src/application/payment/mod.rs
+++ b/marketplace-core/src/application/payment/mod.rs
@@ -1,0 +1,1 @@
+pub mod mark_as_processed;

--- a/marketplace-core/src/graphql/context.rs
+++ b/marketplace-core/src/graphql/context.rs
@@ -1,0 +1,22 @@
+use marketplace_domain::{Publisher, UuidGenerator};
+use marketplace_event_store::Event;
+use std::sync::Arc;
+
+pub struct Context {
+	pub uuid_generator: Arc<dyn UuidGenerator>,
+	pub event_publisher: Arc<dyn Publisher<Event>>,
+}
+
+impl Context {
+	pub fn new(
+		uuid_generator: Arc<dyn UuidGenerator>,
+		event_publisher: Arc<dyn Publisher<Event>>,
+	) -> Self {
+		Self {
+			uuid_generator,
+			event_publisher,
+		}
+	}
+}
+
+impl juniper::Context for Context {}

--- a/marketplace-core/src/graphql/context.rs
+++ b/marketplace-core/src/graphql/context.rs
@@ -1,10 +1,10 @@
+use crate::application;
 use marketplace_domain::{Publisher, UuidGenerator};
 use marketplace_event_store::Event;
 use std::sync::Arc;
 
 pub struct Context {
-	pub uuid_generator: Arc<dyn UuidGenerator>,
-	pub event_publisher: Arc<dyn Publisher<Event>>,
+	pub mark_payment_as_processed_usecase: application::payment::mark_as_processed::Usecase,
 }
 
 impl Context {
@@ -13,8 +13,11 @@ impl Context {
 		event_publisher: Arc<dyn Publisher<Event>>,
 	) -> Self {
 		Self {
-			uuid_generator,
-			event_publisher,
+			mark_payment_as_processed_usecase:
+				application::payment::mark_as_processed::Usecase::new(
+					uuid_generator,
+					event_publisher,
+				),
 		}
 	}
 }

--- a/marketplace-core/src/graphql/mod.rs
+++ b/marketplace-core/src/graphql/mod.rs
@@ -1,10 +1,13 @@
 mod query;
 use query::Query;
 
-use juniper::{EmptyMutation, EmptySubscription, RootNode};
+mod mutation;
+use mutation::Mutation;
 
-pub type Schema = RootNode<'static, Query, EmptyMutation<()>, EmptySubscription<()>>;
+use juniper::{EmptySubscription, RootNode};
+
+pub type Schema = RootNode<'static, Query, Mutation, EmptySubscription<()>>;
 
 pub fn create_schema() -> Schema {
-	Schema::new(Query, EmptyMutation::new(), EmptySubscription::new())
+	Schema::new(Query, Mutation, EmptySubscription::new())
 }

--- a/marketplace-core/src/graphql/mod.rs
+++ b/marketplace-core/src/graphql/mod.rs
@@ -1,14 +1,10 @@
-use juniper::graphql_object;
+mod query;
+use query::Query;
 
-pub struct Query;
+use juniper::{EmptyMutation, EmptySubscription, RootNode};
 
-#[graphql_object]
-impl Query {
-	pub fn new() -> Self {
-		Self {}
-	}
+pub type Schema = RootNode<'static, Query, EmptyMutation<()>, EmptySubscription<()>>;
 
-	pub fn hello(&self) -> &str {
-		"Couscous!"
-	}
+pub fn create_schema() -> Schema {
+	Schema::new(Query, EmptyMutation::new(), EmptySubscription::new())
 }

--- a/marketplace-core/src/graphql/mod.rs
+++ b/marketplace-core/src/graphql/mod.rs
@@ -4,9 +4,12 @@ use query::Query;
 mod mutation;
 use mutation::Mutation;
 
+mod context;
+pub use context::Context;
+
 use juniper::{EmptySubscription, RootNode};
 
-pub type Schema = RootNode<'static, Query, Mutation, EmptySubscription<()>>;
+pub type Schema = RootNode<'static, Query, Mutation, EmptySubscription<Context>>;
 
 pub fn create_schema() -> Schema {
 	Schema::new(Query, Mutation, EmptySubscription::new())

--- a/marketplace-core/src/graphql/mutation.rs
+++ b/marketplace-core/src/graphql/mutation.rs
@@ -1,0 +1,10 @@
+use juniper::graphql_object;
+
+pub struct Mutation;
+
+#[graphql_object]
+impl Mutation {
+	pub fn new() -> Self {
+		Self {}
+	}
+}

--- a/marketplace-core/src/graphql/mutation.rs
+++ b/marketplace-core/src/graphql/mutation.rs
@@ -41,7 +41,7 @@ impl Mutation {
 		.into_iter()
 		.map(|event| Event {
 			deduplication_id: context.uuid_generator.new_uuid().to_string(),
-			event: event.clone().into(),
+			event: event.into(),
 			timestamp: Utc::now().naive_utc(),
 			origin: EventOrigin::BACKEND,
 			metadata: Default::default(),

--- a/marketplace-core/src/graphql/mutation.rs
+++ b/marketplace-core/src/graphql/mutation.rs
@@ -1,10 +1,58 @@
-use juniper::graphql_object;
+use super::Context;
+use chrono::Utc;
+use juniper::{graphql_object, FieldResult, GraphQLInputObject, GraphQLObject};
+use marketplace_domain::{BlockchainNetwork, Destination, Payment, PaymentReceipt};
+use marketplace_event_store::{bus::QUEUE_NAME as EVENT_STORE_QUEUE, Event, EventOrigin};
+use uuid::Uuid;
 
 pub struct Mutation;
 
-#[graphql_object]
+#[derive(GraphQLInputObject)]
+#[graphql(description = "Receipt data of an ethereum payment")]
+struct EthPaymentReceipt {
+	recipient_address: String,
+	transaction_hash: String,
+}
+
+#[derive(GraphQLObject)]
+struct PaymentId {
+	id: Uuid,
+}
+
+#[graphql_object(context=Context)]
 impl Mutation {
 	pub fn new() -> Self {
 		Self {}
+	}
+
+	pub async fn eth_payment_processed(
+		context: &Context,
+		id: Uuid,
+		receipt: EthPaymentReceipt,
+	) -> FieldResult<PaymentId> {
+		let events: Vec<Event> = Payment::mark_as_processed(
+			id.into(),
+			PaymentReceipt::OnChainPayment {
+				network: BlockchainNetwork::Ethereum,
+				recipient_address: receipt.recipient_address.parse()?,
+				transaction_hash: receipt.transaction_hash.parse()?,
+			},
+		)
+		.into_iter()
+		.map(|event| Event {
+			deduplication_id: context.uuid_generator.new_uuid().to_string(),
+			event: event.clone().into(),
+			timestamp: Utc::now().naive_utc(),
+			origin: EventOrigin::BACKEND,
+			metadata: Default::default(),
+		})
+		.collect();
+
+		context
+			.event_publisher
+			.publish_many(Destination::queue(EVENT_STORE_QUEUE), &events)
+			.await?;
+
+		Ok(PaymentId { id })
 	}
 }

--- a/marketplace-core/src/graphql/query.rs
+++ b/marketplace-core/src/graphql/query.rs
@@ -1,0 +1,14 @@
+use juniper::graphql_object;
+
+pub struct Query;
+
+#[graphql_object]
+impl Query {
+	pub fn new() -> Self {
+		Self {}
+	}
+
+	pub fn hello(&self) -> &str {
+		"Couscous!"
+	}
+}

--- a/marketplace-core/src/graphql/query.rs
+++ b/marketplace-core/src/graphql/query.rs
@@ -1,8 +1,9 @@
+use super::Context;
 use juniper::graphql_object;
 
 pub struct Query;
 
-#[graphql_object]
+#[graphql_object(context=Context)]
 impl Query {
 	pub fn new() -> Self {
 		Self {}

--- a/marketplace-core/src/lib.rs
+++ b/marketplace-core/src/lib.rs
@@ -8,10 +8,9 @@ pub mod event_listeners;
 mod graphql;
 mod routes;
 
-use crate::{application::*, graphql::Query, routes::graphql::Schema};
+use crate::application::*;
 use anyhow::Result;
 use dotenv::dotenv;
-use juniper::{EmptyMutation, EmptySubscription};
 use log::info;
 use marketplace_domain::*;
 use marketplace_infrastructure::{
@@ -42,7 +41,7 @@ pub async fn main() -> Result<()> {
 	let uuid_generator = Arc::new(RandomUuidGenerator);
 	let contribution_repository: AggregateRootRepository<Contribution> =
 		AggregateRootRepository::new(database.clone());
-	let graphql_schema = Schema::new(Query, EmptyMutation::new(), EmptySubscription::new());
+	let graphql_schema = graphql::create_schema();
 
 	let rocket_handler = inject_app(
 		rocket::build(),

--- a/marketplace-core/src/routes/graphql.rs
+++ b/marketplace-core/src/routes/graphql.rs
@@ -1,9 +1,5 @@
-use juniper::{EmptyMutation, EmptySubscription, RootNode};
+use crate::graphql::Schema;
 use rocket::{response::content, State};
-
-use crate::graphql::Query;
-
-pub type Schema = RootNode<'static, Query, EmptyMutation<()>, EmptySubscription<()>>;
 
 #[get("/")]
 pub fn graphiql() -> content::RawHtml<String> {

--- a/marketplace-core/src/routes/graphql.rs
+++ b/marketplace-core/src/routes/graphql.rs
@@ -1,4 +1,4 @@
-use crate::graphql::Schema;
+use crate::graphql::{Context, Schema};
 use rocket::{response::content, State};
 
 #[get("/")]
@@ -10,14 +10,16 @@ pub fn graphiql() -> content::RawHtml<String> {
 pub fn get_graphql_handler(
 	request: juniper_rocket::GraphQLRequest,
 	schema: &State<Schema>,
+	context: &State<Context>,
 ) -> juniper_rocket::GraphQLResponse {
-	request.execute_sync(&**schema, &())
+	request.execute_sync(&**schema, &**context)
 }
 
 #[post("/graphql", data = "<request>")]
 pub fn post_graphql_handler(
 	request: juniper_rocket::GraphQLRequest,
 	schema: &State<Schema>,
+	context: &State<Context>,
 ) -> juniper_rocket::GraphQLResponse {
-	request.execute_sync(&**schema, &())
+	request.execute_sync(&**schema, &**context)
 }

--- a/marketplace-core/src/routes/graphql.rs
+++ b/marketplace-core/src/routes/graphql.rs
@@ -13,7 +13,7 @@ pub async fn get_graphql_handler(
 	schema: &State<Schema>,
 	context: &State<Context>,
 ) -> GraphQLResponse {
-	request.execute(&**schema, &**context).await
+	request.execute(schema, context).await
 }
 
 #[post("/graphql", data = "<request>")]
@@ -22,5 +22,5 @@ pub async fn post_graphql_handler(
 	schema: &State<Schema>,
 	context: &State<Context>,
 ) -> GraphQLResponse {
-	request.execute(&**schema, &**context).await
+	request.execute(schema, context).await
 }

--- a/marketplace-core/src/routes/graphql.rs
+++ b/marketplace-core/src/routes/graphql.rs
@@ -1,4 +1,5 @@
 use crate::graphql::{Context, Schema};
+use juniper_rocket::{GraphQLRequest, GraphQLResponse};
 use rocket::{response::content, State};
 
 #[get("/")]
@@ -7,19 +8,19 @@ pub fn graphiql() -> content::RawHtml<String> {
 }
 
 #[get("/graphql?<request>")]
-pub fn get_graphql_handler(
-	request: juniper_rocket::GraphQLRequest,
+pub async fn get_graphql_handler(
+	request: GraphQLRequest,
 	schema: &State<Schema>,
 	context: &State<Context>,
-) -> juniper_rocket::GraphQLResponse {
-	request.execute_sync(&**schema, &**context)
+) -> GraphQLResponse {
+	request.execute(&**schema, &**context).await
 }
 
 #[post("/graphql", data = "<request>")]
-pub fn post_graphql_handler(
-	request: juniper_rocket::GraphQLRequest,
+pub async fn post_graphql_handler(
+	request: GraphQLRequest,
 	schema: &State<Schema>,
 	context: &State<Context>,
-) -> juniper_rocket::GraphQLResponse {
-	request.execute_sync(&**schema, &**context)
+) -> GraphQLResponse {
+	request.execute(&**schema, &**context).await
 }

--- a/marketplace-domain/src/payment/aggregate.rs
+++ b/marketplace-domain/src/payment/aggregate.rs
@@ -1,6 +1,5 @@
-use crate::{Aggregate, PaymentEvent, PaymentId};
+use crate::{Aggregate, PaymentEvent, PaymentId, PaymentReceipt};
 use serde::{Deserialize, Serialize};
-
 #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Payment {
 	id: PaymentId,
@@ -9,4 +8,13 @@ pub struct Payment {
 impl Aggregate for Payment {
 	type Event = PaymentEvent;
 	type Id = PaymentId;
+}
+
+impl Payment {
+	pub fn mark_as_processed(
+		id: PaymentId,
+		receipt: PaymentReceipt,
+	) -> Vec<<Self as Aggregate>::Event> {
+		vec![PaymentEvent::Processed { id, receipt }]
+	}
 }


### PR DESCRIPTION
- ♻️ move graphql definitions in dedicated module
- ✨ create graphql mutation root object
- ✨ add Payment::mark_as_processed command
- ✨ introduce graphql context to inject dependencies
- ✨ create the eth_payment_processed mutation
- ♻️ make graphql endpoint async
