### PR TITLE
Improve AMQP and event store error handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,7 +141,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           codecov_token: ${{ secrets.CODECOV_TOKEN }}
-          test_flags: -p marketplace-infrastructure -p marketplace-event-store --features with_infrastructure_tests
+          test_flags: -p marketplace-infrastructure -p event-store --features with_infrastructure_tests
           codecov_flag: infrastructure
 
   e2e_tests:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,7 +141,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           codecov_token: ${{ secrets.CODECOV_TOKEN }}
-          test_flags: -p marketplace-infrastructure --features with_infrastructure_tests
+          test_flags: -p marketplace-infrastructure -p marketplace-event-store --features with_infrastructure_tests
           codecov_flag: infrastructure
 
   e2e_tests:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1857,6 +1857,7 @@ version = "0.0.1"
 dependencies = [
  "anyhow",
  "assert_matches",
+ "async-std",
  "async-trait",
  "chrono",
  "claim",
@@ -1891,6 +1892,7 @@ dependencies = [
  "tracing-log",
  "tracing-opentelemetry",
  "tracing-subscriber",
+ "tracing-test",
  "url",
  "uuid 0.8.2",
  "wiremock",
@@ -3799,6 +3801,29 @@ dependencies = [
  "tracing-core",
  "tracing-log",
  "tracing-serde",
+]
+
+[[package]]
+name = "tracing-test"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e3d272c44878d2bbc9f4a20ad463724f03e19dbc667c6e84ac433ab7ffcc70b"
+dependencies = [
+ "lazy_static",
+ "tracing-core",
+ "tracing-subscriber",
+ "tracing-test-macro",
+]
+
+[[package]]
+name = "tracing-test-macro"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "744324b12d69a9fc1edea4b38b7b1311295b662d161ad5deac17bb1358224a08"
+dependencies = [
+ "lazy_static",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/event-store/Cargo.toml
+++ b/event-store/Cargo.toml
@@ -9,6 +9,9 @@ readme = "README.md"
 repository = "https://github.com/onlydustxyz/marketplace-backend"
 version = "0.0.1"
 
+[features]
+with_infrastructure_tests = []
+
 [dependencies]
 # Database
 diesel = {version = "1.4.8", default-features = false, features = [

--- a/event-store/src/domain/store.rs
+++ b/event-store/src/domain/store.rs
@@ -12,5 +12,5 @@ pub enum Error {
 }
 
 pub trait Store: Send + Sync {
-	fn append(&self, aggregate_id: &str, events: Vec<Event>) -> Result<(), Error>;
+	fn append(&self, aggregate_id: &str, event: Event) -> Result<(), Error>;
 }

--- a/event-store/src/infrastructure/database/store.rs
+++ b/event-store/src/infrastructure/database/store.rs
@@ -1,9 +1,9 @@
 use crate::{domain::*, infrastructure::database::models, Event};
-use diesel::prelude::*;
+use diesel::{dsl::exists, prelude::*};
 use log::error;
 use marketplace_domain::Event as DomainEvent;
 use marketplace_infrastructure::database::{
-	schema::{event_deduplications, events, events::index},
+	schema::{event_deduplications, event_deduplications::dsl, events, events::index},
 	Client,
 };
 use serde_json::{to_value as to_json, Value as Json};
@@ -26,54 +26,55 @@ impl NamedAggregate for Event {
 }
 
 impl EventStore for Client {
-	fn append(&self, aggregate_id: &str, storable_events: Vec<Event>) -> Result<()> {
+	fn append(&self, aggregate_id: &str, storable_event: Event) -> Result<()> {
 		let connection = self.connection().map_err(|e| {
 			error!("Failed to connect to database: {e}");
 			EventStoreError::Connection(e.into())
 		})?;
 
-		let events = storable_events
-			.iter()
-			.map(|storable_event| {
-				let domain_event = storable_event.event.clone();
-				Ok(models::Event {
-					timestamp: storable_event.timestamp,
-					aggregate_name: storable_event.aggregate_name().to_owned(),
-					aggregate_id: aggregate_id.to_owned(),
-					payload: serialize_event(&domain_event)?,
-					origin: storable_event.origin.to_string(),
-					metadata: storable_event.metadata.clone(),
-				})
-			})
-			.collect::<Result<Vec<_>>>()?;
+		let domain_event = storable_event.event.clone();
+		let event = models::Event {
+			timestamp: storable_event.timestamp,
+			aggregate_name: storable_event.aggregate_name().to_owned(),
+			aggregate_id: aggregate_id.to_owned(),
+			payload: serialize_event(&domain_event)?,
+			origin: storable_event.origin.to_string(),
+			metadata: storable_event.metadata.clone(),
+		};
 
 		connection
 			.transaction(|| {
-				let inserted_events: Vec<i32> = diesel::insert_into(events::table)
-					.values(&events)
+				let already_exists: bool = diesel::select(exists(
+					dsl::event_deduplications
+						.filter(dsl::deduplication_id.eq(storable_event.deduplication_id.clone())),
+				))
+				.get_result(&*connection)?;
+
+				if already_exists {
+					error!(
+						"Event with same deduplication_id ({}) already exists. This event will be ignored.",
+						storable_event.deduplication_id
+					);
+					return Ok(());
+				}
+
+				let inserted_event_index: i32 = diesel::insert_into(events::table)
+					.values(&event)
 					.returning(index)
-					.get_results(&*connection)?;
+					.get_result(&*connection)?;
 
-				assert_eq!(
-					inserted_events.len(),
-					storable_events.len(),
-					"list of inserted events and storable events should never have different lengths"
-				);
-
-				let deduplications = storable_events
-					.iter()
-					.zip(inserted_events)
-					.map(|event| models::EventDeduplication {
-						deduplication_id: event.0.deduplication_id.clone(),
-						event_index: event.1,
-					})
-					.collect::<Vec<_>>();
+				let deduplication = models::EventDeduplication {
+					deduplication_id: storable_event.deduplication_id.clone(),
+					event_index: inserted_event_index,
+				};
 
 				diesel::insert_into(event_deduplications::table)
-					.values(&deduplications)
-					.execute(&*connection)
+					.values(&deduplication)
+					.execute(&*connection)?;
+
+				Ok(())
 			})
-			.map_err(|e| {
+			.map_err(|e: diesel::result::Error| {
 				error!("Failed to insert event(s) into database: {e}");
 				EventStoreError::Append(e.into())
 			})?;

--- a/event-store/src/lib.rs
+++ b/event-store/src/lib.rs
@@ -42,7 +42,7 @@ async fn store(store: Arc<dyn EventStore>, event: Event) -> Result<Event, Subscr
 
 	store
 		.append(&event.aggregate_id(), event.clone())
-		.map_err(|e| SubscriberCallbackError::InternalError(e.into()))?;
+		.map_err(|e| SubscriberCallbackError::Fatal(e.into()))?;
 
 	Ok(event)
 }
@@ -54,7 +54,7 @@ async fn publish(
 	publisher
 		.publish(Destination::exchange(EXCHANGE_NAME), &event.event)
 		.await
-		.map_err(|e| SubscriberCallbackError::InternalError(e.into()))?;
+		.map_err(|e| SubscriberCallbackError::Fatal(e.into()))?;
 	Ok(())
 }
 

--- a/event-store/src/lib.rs
+++ b/event-store/src/lib.rs
@@ -41,7 +41,7 @@ async fn store(store: Arc<dyn EventStore>, event: Event) -> Result<Event, Subscr
 	}
 
 	store
-		.append(&event.aggregate_id(), vec![event.clone()])
+		.append(&event.aggregate_id(), event.clone())
 		.map_err(|e| SubscriberCallbackError::InternalError(e.into()))?;
 
 	Ok(event)

--- a/marketplace-core/src/event_listeners/logger.rs
+++ b/marketplace-core/src/event_listeners/logger.rs
@@ -1,12 +1,12 @@
 use anyhow::Result;
-use marketplace_domain::{Event, Subscriber};
+use marketplace_domain::{Event, Subscriber, SubscriberCallbackError};
 use marketplace_infrastructure::amqp::ConsumableBus;
 use tokio::task::JoinHandle;
 
-async fn log(event: Event) -> Result<()> {
+async fn log(event: Event) -> Result<(), SubscriberCallbackError> {
 	info!(
 		"[events] 📨 Received event: {}",
-		&serde_json::to_string_pretty(&event)?
+		&serde_json::to_string_pretty(&event).unwrap_or_default()
 	);
 	Ok(())
 }

--- a/marketplace-core/src/event_listeners/projector.rs
+++ b/marketplace-core/src/event_listeners/projector.rs
@@ -1,10 +1,13 @@
 use anyhow::Result;
-use marketplace_domain::{Event, EventListener, Subscriber};
+use marketplace_domain::{Event, EventListener, Subscriber, SubscriberCallbackError};
 use marketplace_infrastructure::amqp::ConsumableBus;
 use std::sync::Arc;
 use tokio::task::JoinHandle;
 
-async fn notify_event_listener(listener: Arc<dyn EventListener>, event: Event) -> Result<()> {
+async fn notify_event_listener(
+	listener: Arc<dyn EventListener>,
+	event: Event,
+) -> Result<(), SubscriberCallbackError> {
 	listener.on_event(&event).await;
 	Ok(())
 }

--- a/marketplace-domain/src/lib.rs
+++ b/marketplace-domain/src/lib.rs
@@ -20,7 +20,10 @@ mod event_listener;
 pub use event_listener::{EventListener, MockEventListener};
 
 mod messaging;
-pub use messaging::{Destination, Message, Publisher, PublisherError, Subscriber, SubscriberError};
+pub use messaging::{
+	Destination, Message, Publisher, PublisherError, Subscriber, SubscriberCallbackError,
+	SubscriberError,
+};
 
 mod projection;
 pub use projection::Projection;

--- a/marketplace-domain/src/messaging/mod.rs
+++ b/marketplace-domain/src/messaging/mod.rs
@@ -5,7 +5,9 @@ mod publisher;
 pub use publisher::{Error as PublisherError, Publisher};
 
 mod subscriber;
-pub use subscriber::{Error as SubscriberError, Subscriber};
+pub use subscriber::{
+	CallbackError as SubscriberCallbackError, Error as SubscriberError, Subscriber,
+};
 
 mod destination;
 pub use destination::Destination;

--- a/marketplace-domain/src/messaging/subscriber.rs
+++ b/marketplace-domain/src/messaging/subscriber.rs
@@ -19,14 +19,15 @@ pub enum Error {
 
 #[derive(Debug, Error)]
 pub enum CallbackError {
-	// Returning a BadMessage error will discard the current message. It won't be requeued.
-	#[error("Invalid message")]
-	BadMessage(#[source] anyhow::Error),
+	// Returning a Discard error will discard the current message and process the next one. It
+	// won't be requeued.
+	#[error("Ignoring message")]
+	Discard(#[source] anyhow::Error),
 
-	// Returning an InternalError error will stop the consuming of messages. The current message
-	// will be automatically requeued.
-	#[error("Internal error while processing the message")]
-	InternalError(#[from] anyhow::Error),
+	// Returning an Fatal error will stop the consuming of messages. The current message
+	// must be automatically requeued by the message broker.
+	#[error("Fatal error while processing the message")]
+	Fatal(#[from] anyhow::Error),
 }
 
 #[async_trait]

--- a/marketplace-domain/src/messaging/subscriber.rs
+++ b/marketplace-domain/src/messaging/subscriber.rs
@@ -1,5 +1,4 @@
 use super::Message;
-use anyhow::Result as AnyResult;
 use async_trait::async_trait;
 use std::future::Future;
 use thiserror::Error;
@@ -18,10 +17,22 @@ pub enum Error {
 	Deserialize(#[from] serde_json::Error),
 }
 
+#[derive(Debug, Error)]
+pub enum CallbackError {
+	// Returning a BadMessage error will discard the current message. It won't be requeued.
+	#[error("Invalid message")]
+	BadMessage(#[source] anyhow::Error),
+
+	// Returning an InternalError error will stop the consuming of messages. The current message
+	// will be automatically requeued.
+	#[error("Internal error while processing the message")]
+	InternalError(#[from] anyhow::Error),
+}
+
 #[async_trait]
 pub trait Subscriber<M: Message> {
 	async fn subscribe<C, F>(&self, callback: C) -> Result<(), Error>
 	where
 		C: Fn(M) -> F + Send + Sync,
-		F: Future<Output = AnyResult<()>> + Send;
+		F: Future<Output = Result<(), CallbackError>> + Send;
 }

--- a/marketplace-infrastructure/Cargo.toml
+++ b/marketplace-infrastructure/Cargo.toml
@@ -84,6 +84,7 @@ marketplace-domain = {path = "../marketplace-domain"}
 testing = {path = "../testing"}
 
 [dev-dependencies]
+async-std = {version = "1.12.0", features = ["attributes"]}
 assert_matches = "1.5"
 claim = "0.5"
 envtestkit = "1.1.2"
@@ -91,3 +92,4 @@ mockito = "0.31.0"
 rand = "0.8.5"
 rstest = "0.15.0"
 wiremock = "0.5"
+tracing-test = "0.2.3"

--- a/marketplace-infrastructure/src/amqp/subscriber.rs
+++ b/marketplace-infrastructure/src/amqp/subscriber.rs
@@ -1,39 +1,76 @@
 use super::ConsumableBus;
 use anyhow::anyhow;
 use async_trait::async_trait;
-use log::error;
-use marketplace_domain::{Message, Subscriber, SubscriberError};
+use lapin::{message::Delivery, options::BasicNackOptions};
+use marketplace_domain::{Message, Subscriber, SubscriberCallbackError, SubscriberError};
+use serde_json::Error;
 use std::future::Future;
+use tracing::error;
 
 #[async_trait]
 impl<M: Message + Send + Sync> Subscriber<M> for ConsumableBus {
 	async fn subscribe<C, F>(&self, callback: C) -> Result<(), SubscriberError>
 	where
 		C: Fn(M) -> F + Send + Sync,
-		F: Future<Output = Result<(), anyhow::Error>> + Send,
+		F: Future<Output = Result<(), SubscriberCallbackError>> + Send,
 	{
 		while let Some(delivery) =
 			self.consume().await.map_err(|e| SubscriberError::Receive(anyhow!(e)))?
 		{
-			let message: M = serde_json::from_slice(&delivery.data)?;
+			let message: Result<M, Error> = serde_json::from_slice(&delivery.data);
+			let message = match message {
+				Ok(message) => message,
+				Err(error) => {
+					error!(
+						error = error.to_string(),
+						message = format!("{:?}", delivery.data),
+						"Failed to deserialize message",
+					);
+					Self::discard_message(&delivery).await?;
+					continue;
+				},
+			};
+
 			match callback(message).await {
 				Ok(_) => delivery
 					.ack(Default::default())
 					.await
 					.map_err(|e| SubscriberError::Ack(anyhow!(e)))?,
 
-				Err(error) => {
-					error!("{error}");
-					delivery
-						.nack(Default::default())
-						.await
-						.map_err(|e| SubscriberError::Nack(anyhow!(e)))?;
-
-					return Err(SubscriberError::Processing(error));
+				Err(error) => match error {
+					SubscriberCallbackError::BadMessage(error) => {
+						error!(
+							error = error.to_string(),
+							message = format!("{:?}", delivery.data),
+							"Invalid message",
+						);
+						Self::discard_message(&delivery).await?;
+						continue;
+					},
+					SubscriberCallbackError::InternalError(error) => {
+						error!(
+							error = error.to_string(),
+							message = format!("{:?}", delivery.data),
+							"Failed to process message due to internal error",
+						);
+						return Err(SubscriberError::Processing(error));
+					},
 				},
 			}
 		}
 
 		Ok(())
+	}
+}
+
+impl ConsumableBus {
+	async fn discard_message(delivery: &Delivery) -> Result<(), SubscriberError> {
+		delivery
+			.nack(BasicNackOptions {
+				requeue: false,
+				..Default::default()
+			})
+			.await
+			.map_err(|e| SubscriberError::Nack(anyhow!(e)))
 	}
 }

--- a/marketplace-infrastructure/src/amqp/subscriber.rs
+++ b/marketplace-infrastructure/src/amqp/subscriber.rs
@@ -74,3 +74,200 @@ impl ConsumableBus {
 			.map_err(|e| SubscriberError::Nack(anyhow!(e)))
 	}
 }
+
+#[cfg(test)]
+
+mod tests {
+	use crate::amqp::{Bus, ConsumableBus};
+	use anyhow::anyhow;
+	use lapin::options::QueueDeclareOptions;
+	use marketplace_domain::{Message, Subscriber, SubscriberCallbackError, SubscriberError};
+	use mockall::lazy_static;
+	use rstest::rstest;
+	use serde::{Deserialize, Serialize};
+	use std::sync::{
+		atomic::{AtomicI32, Ordering},
+		Arc,
+	};
+	use tracing_test::traced_test;
+
+	#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+	enum TestMessage {
+		Valid,
+		Invalid,
+		Stop, // special value to end the test
+	}
+	impl Message for TestMessage {}
+
+	async fn init_consumer(queue_name: &'static str) -> ConsumableBus {
+		Bus::default()
+			.await
+			.unwrap()
+			.with_queue(
+				queue_name,
+				QueueDeclareOptions {
+					durable: false,    // do not persist messages
+					exclusive: true,   // only one consumer on this queue
+					auto_delete: true, // delete the queue at shutdown
+					..Default::default()
+				},
+			)
+			.await
+			.unwrap()
+	}
+
+	async fn publish_message(queue_name: &'static str, message: TestMessage) {
+		let confirmation = Bus::default()
+			.await
+			.unwrap()
+			.publish(
+				&*String::new(),
+				queue_name,
+				&serde_json::to_vec(&message).unwrap(),
+			)
+			.await
+			.unwrap();
+
+		assert!(!confirmation.is_nack());
+	}
+
+	async fn publish_badly_formatted_message(queue_name: &'static str) {
+		let confirmation = Bus::default()
+			.await
+			.unwrap()
+			.publish(&*String::new(), queue_name, "bad-message".as_bytes())
+			.await
+			.unwrap();
+
+		assert!(!confirmation.is_nack());
+	}
+
+	fn assert_error_message(error: SubscriberError, expected_error_message: &str) {
+		match error {
+			SubscriberError::Processing(error) => {
+				assert_eq!(error.to_string(), expected_error_message.to_string());
+			},
+			_ => panic!(),
+		}
+	}
+
+	async fn run_test(
+		consumer: ConsumableBus,
+		counter: &'static Arc<AtomicI32>,
+		expect_valid_message_count: i32,
+	) {
+		const STOP_ERROR: &str = "stop the test";
+		const BAD_MESSAGE_ERROR: &str = "bad message";
+
+		let result = consumer
+			.subscribe(|message: TestMessage| async move {
+				match message {
+					TestMessage::Valid => {
+						counter.fetch_add(1, Ordering::SeqCst);
+						Ok(())
+					},
+					TestMessage::Invalid => Err(SubscriberCallbackError::BadMessage(anyhow!(
+						BAD_MESSAGE_ERROR
+					))),
+					TestMessage::Stop =>
+						Err(SubscriberCallbackError::InternalError(anyhow!(STOP_ERROR))),
+				}
+			})
+			.await;
+
+		assert_error_message(result.unwrap_err(), STOP_ERROR);
+		assert_eq!(counter.load(Ordering::SeqCst), expect_valid_message_count);
+	}
+
+	#[rstest]
+	#[cfg_attr(
+		not(feature = "with_infrastructure_tests"),
+		ignore = "infrastructure test"
+	)]
+	async fn process_valid_messages_successfully() {
+		const QUEUE: &str = "receive_valid_message_and_process_it_successfully";
+		lazy_static! {
+			static ref COUNTER: Arc<AtomicI32> = Arc::new(AtomicI32::new(0));
+		}
+
+		let consumer = init_consumer(QUEUE).await;
+		publish_message(QUEUE, TestMessage::Valid).await;
+		publish_message(QUEUE, TestMessage::Valid).await;
+		publish_message(QUEUE, TestMessage::Stop).await;
+
+		run_test(consumer, &*COUNTER, 2).await;
+	}
+
+	#[rstest]
+	#[traced_test]
+	#[cfg_attr(
+		not(feature = "with_infrastructure_tests"),
+		ignore = "infrastructure test"
+	)]
+	async fn ignore_non_deserializable_message() {
+		const QUEUE: &str = "ignore_non_deserializable_message";
+		lazy_static! {
+			static ref COUNTER: Arc<AtomicI32> = Arc::new(AtomicI32::new(0));
+		}
+
+		let consumer = init_consumer(QUEUE).await;
+		publish_message(QUEUE, TestMessage::Valid).await;
+		publish_badly_formatted_message(QUEUE).await;
+		publish_message(QUEUE, TestMessage::Valid).await;
+		publish_message(QUEUE, TestMessage::Stop).await;
+
+		run_test(consumer, &*COUNTER, 2).await;
+
+		assert!(logs_contain("Failed to deserialize message"));
+	}
+
+	#[rstest]
+	#[traced_test]
+	#[cfg_attr(
+		not(feature = "with_infrastructure_tests"),
+		ignore = "infrastructure test"
+	)]
+	async fn ignore_bad_message() {
+		const QUEUE: &str = "ignore_bad_message";
+		lazy_static! {
+			static ref COUNTER: Arc<AtomicI32> = Arc::new(AtomicI32::new(0));
+		}
+
+		let consumer = init_consumer(QUEUE).await;
+		publish_message(QUEUE, TestMessage::Valid).await;
+		publish_message(QUEUE, TestMessage::Invalid).await;
+		publish_message(QUEUE, TestMessage::Valid).await;
+		publish_message(QUEUE, TestMessage::Stop).await;
+
+		run_test(consumer, &*COUNTER, 2).await;
+
+		assert!(logs_contain("Invalid message error=\"bad message\""));
+	}
+
+	#[rstest]
+	#[traced_test]
+	#[cfg_attr(
+		not(feature = "with_infrastructure_tests"),
+		ignore = "infrastructure test"
+	)]
+	async fn terminate_message_consuming_because_of_internal_error() {
+		const QUEUE: &str = "terminate_message_consuming_because_of_internal_error";
+		const ERROR: &str = "some internal error occurred";
+
+		let consumer = init_consumer(QUEUE).await;
+		publish_message(QUEUE, TestMessage::Valid).await;
+
+		let result = consumer
+			.subscribe(|message: TestMessage| async move {
+				assert_eq!(message, TestMessage::Valid);
+				Err(SubscriberCallbackError::InternalError(anyhow!(ERROR)))
+			})
+			.await;
+
+		assert_error_message(result.unwrap_err(), ERROR);
+
+		assert!(logs_contain(
+			"Failed to process message due to internal error error=\"some internal error occurred\""
+		));
+	}
+}


### PR DESCRIPTION
- :recycle: Improve subscriber error handling
- :recycle: in case of duplicated events, the event store repository logs an error but returns Ok to simply ignore the event
- :white_check_mark: add some infrastructure tests for amqp
