### PR TITLE
Project project events

### DIFF
--- a/event-listeners/src/domain/mod.rs
+++ b/event-listeners/src/domain/mod.rs
@@ -2,7 +2,7 @@ mod event_listener;
 pub use event_listener::EventListener;
 
 mod projections;
-pub use projections::{Payment, PaymentRequest, Projection, Repository as ProjectionRepository};
+pub use projections::{Repository as ProjectionRepository, *};
 
 mod projectors;
 pub use projectors::{PaymentProjector, PaymentRequestProjector};

--- a/event-listeners/src/domain/mod.rs
+++ b/event-listeners/src/domain/mod.rs
@@ -5,4 +5,4 @@ mod projections;
 pub use projections::{Repository as ProjectionRepository, *};
 
 mod projectors;
-pub use projectors::{PaymentProjector, PaymentRequestProjector};
+pub use projectors::*;

--- a/event-listeners/src/domain/projections/mod.rs
+++ b/event-listeners/src/domain/projections/mod.rs
@@ -2,9 +2,12 @@
 mod payment;
 #[allow(clippy::extra_unused_lifetimes)]
 mod payment_request;
+#[allow(clippy::extra_unused_lifetimes)]
+mod project;
 
 pub use payment::Payment;
 pub use payment_request::PaymentRequest;
+pub use project::Project;
 
 pub trait Projection {
 	type Id;

--- a/event-listeners/src/domain/projections/mod.rs
+++ b/event-listeners/src/domain/projections/mod.rs
@@ -4,10 +4,13 @@ mod payment;
 mod payment_request;
 #[allow(clippy::extra_unused_lifetimes)]
 mod project;
+#[allow(clippy::extra_unused_lifetimes)]
+mod project_lead;
 
 pub use payment::Payment;
 pub use payment_request::PaymentRequest;
 pub use project::Project;
+pub use project_lead::{ProjectLead, Repository as ProjectLeadRepository};
 
 pub trait Projection {
 	type Id;

--- a/event-listeners/src/domain/projections/project.rs
+++ b/event-listeners/src/domain/projections/project.rs
@@ -1,0 +1,19 @@
+use super::Projection;
+use infrastructure::database::schema::projects;
+use uuid::Uuid;
+
+#[derive(Debug, Insertable, Identifiable, AsChangeset)]
+pub struct Project {
+	id: Uuid,
+	name: String,
+}
+
+impl Project {
+	pub fn new(id: Uuid, name: String) -> Self {
+		Self { id, name }
+	}
+}
+
+impl Projection for Project {
+	type Id = Uuid;
+}

--- a/event-listeners/src/domain/projections/project_lead.rs
+++ b/event-listeners/src/domain/projections/project_lead.rs
@@ -1,0 +1,31 @@
+use super::Projection;
+use anyhow::Result;
+use infrastructure::database::schema::project_leads;
+use uuid::Uuid;
+
+#[derive(Debug, Insertable, Identifiable)]
+#[primary_key(project_id, user_id)]
+pub struct ProjectLead {
+	project_id: Uuid,
+	user_id: Uuid,
+}
+
+impl ProjectLead {
+	pub fn new(project_id: Uuid, user_id: Uuid) -> Self {
+		Self {
+			project_id,
+			user_id,
+		}
+	}
+}
+
+impl Projection for ProjectLead {
+	type Id = Uuid;
+}
+
+pub trait Repository: Send + Sync {
+	fn insert(&self, projection: &ProjectLead) -> Result<()>;
+	fn update(&self, project_id: &Uuid, leader_id: &Uuid) -> Result<()>;
+	fn delete(&self, project_id: &Uuid, leader_id: &Uuid) -> Result<()>;
+	fn clear(&self) -> Result<()>;
+}

--- a/event-listeners/src/domain/projectors/mod.rs
+++ b/event-listeners/src/domain/projectors/mod.rs
@@ -4,3 +4,4 @@ mod project;
 
 pub use payment::Projector as PaymentProjector;
 pub use payment_request::Projector as PaymentRequestProjector;
+pub use project::Projector as ProjectProjector;

--- a/event-listeners/src/domain/projectors/mod.rs
+++ b/event-listeners/src/domain/projectors/mod.rs
@@ -1,5 +1,6 @@
 mod payment;
 mod payment_request;
+mod project;
 
 pub use payment::Projector as PaymentProjector;
 pub use payment_request::Projector as PaymentRequestProjector;

--- a/event-listeners/src/domain/projectors/project.rs
+++ b/event-listeners/src/domain/projectors/project.rs
@@ -1,16 +1,26 @@
-use crate::domain::{projections::Project, EventListener, Payment, ProjectionRepository};
+use crate::domain::{
+	projections::{Project, ProjectLead},
+	EventListener, ProjectLeadRepository, ProjectionRepository,
+};
 use anyhow::Result;
 use async_trait::async_trait;
 use domain::{Event, ProjectEvent};
 use std::sync::Arc;
 
 pub struct Projector {
-	repository: Arc<dyn ProjectionRepository<Project>>,
+	project_repository: Arc<dyn ProjectionRepository<Project>>,
+	project_lead_repository: Arc<dyn ProjectLeadRepository>,
 }
 
 impl Projector {
-	pub fn new(repository: Arc<dyn ProjectionRepository<Project>>) -> Self {
-		Self { repository }
+	pub fn new(
+		project_repository: Arc<dyn ProjectionRepository<Project>>,
+		project_lead_repository: Arc<dyn ProjectLeadRepository>,
+	) -> Self {
+		Self {
+			project_repository,
+			project_lead_repository,
+		}
 	}
 }
 
@@ -20,8 +30,10 @@ impl EventListener for Projector {
 		if let Event::Project(event) = event {
 			match event {
 				ProjectEvent::Created { id, name } =>
-					__self.repository.insert(&Project::new((*id).into(), name.to_owned()))?,
-				ProjectEvent::LeaderAssigned { id, leader_id } => todo!(),
+					self.project_repository.insert(&Project::new((*id).into(), name.to_owned()))?,
+				ProjectEvent::LeaderAssigned { id, leader_id } => self
+					.project_lead_repository
+					.insert(&ProjectLead::new((*id).into(), (*leader_id).into()))?,
 			}
 		}
 		Ok(())

--- a/event-listeners/src/domain/projectors/project.rs
+++ b/event-listeners/src/domain/projectors/project.rs
@@ -1,0 +1,29 @@
+use crate::domain::{projections::Project, EventListener, Payment, ProjectionRepository};
+use anyhow::Result;
+use async_trait::async_trait;
+use domain::{Event, ProjectEvent};
+use std::sync::Arc;
+
+pub struct Projector {
+	repository: Arc<dyn ProjectionRepository<Project>>,
+}
+
+impl Projector {
+	pub fn new(repository: Arc<dyn ProjectionRepository<Project>>) -> Self {
+		Self { repository }
+	}
+}
+
+#[async_trait]
+impl EventListener for Projector {
+	async fn on_event(&self, event: &Event) -> Result<()> {
+		if let Event::Project(event) = event {
+			match event {
+				ProjectEvent::Created { id, name } =>
+					__self.repository.insert(&Project::new((*id).into(), name.to_owned()))?,
+				ProjectEvent::LeaderAssigned { id, leader_id } => todo!(),
+			}
+		}
+		Ok(())
+	}
+}

--- a/event-listeners/src/infrastructure/database/mod.rs
+++ b/event-listeners/src/infrastructure/database/mod.rs
@@ -1,7 +1,9 @@
 mod payment;
 mod payment_request;
 mod project;
+mod project_lead;
 
 pub use payment::Repository as PaymentRepository;
 pub use payment_request::Repository as PaymentRequestRepository;
 pub use project::Repository as ProjectRepository;
+pub use project_lead::Repository as ProjectLeadRepository;

--- a/event-listeners/src/infrastructure/database/mod.rs
+++ b/event-listeners/src/infrastructure/database/mod.rs
@@ -1,5 +1,7 @@
 mod payment;
 mod payment_request;
+mod project;
 
 pub use payment::Repository as PaymentRepository;
 pub use payment_request::Repository as PaymentRequestRepository;
+pub use project::Repository as ProjectRepository;

--- a/event-listeners/src/infrastructure/database/project.rs
+++ b/event-listeners/src/infrastructure/database/project.rs
@@ -1,0 +1,16 @@
+use std::sync::Arc;
+
+use crate::domain::Project;
+use infrastructure::database::{schema::projects::dsl, Client};
+
+#[derive(DieselRepository)]
+#[projection(Project)]
+#[table(dsl::projects)]
+#[id(dsl::id)]
+pub struct Repository(Arc<Client>);
+
+impl Repository {
+	pub fn new(client: Arc<Client>) -> Self {
+		Self(client)
+	}
+}

--- a/event-listeners/src/infrastructure/database/project_lead.rs
+++ b/event-listeners/src/infrastructure/database/project_lead.rs
@@ -1,0 +1,51 @@
+use std::sync::Arc;
+
+use crate::{
+	diesel::{ExpressionMethods, QueryDsl, RunQueryDsl},
+	domain::ProjectLead,
+};
+use infrastructure::database::{schema::project_leads::dsl, Client};
+use uuid::Uuid;
+
+pub struct Repository(Arc<Client>);
+
+impl Repository {
+	pub fn new(client: Arc<Client>) -> Self {
+		Self(client)
+	}
+
+	fn insert(&self, projection: &ProjectLead) -> anyhow::Result<()> {
+		let connection = self.0.connection()?;
+		diesel::insert_into(dsl::project_leads)
+			.values(projection)
+			.execute(&*connection)?;
+		Ok(())
+	}
+
+	fn update(&self, project_id: &Uuid, leader_id: &Uuid) -> anyhow::Result<()> {
+		let connection = self.0.connection()?;
+		diesel::update(
+			dsl::project_leads
+				.filter(dsl::project_id.eq(project_id))
+				.filter(dsl::user_id.eq(leader_id)),
+		)
+		.set((dsl::project_id.eq(project_id), dsl::user_id.eq(leader_id)))
+		.execute(&*connection)?;
+		Ok(())
+	}
+
+	fn delete(&self, project_id: &Uuid, leader_id: &Uuid) -> anyhow::Result<()> {
+		let connection = self.0.connection()?;
+		diesel::delete(dsl::project_leads)
+			.filter(dsl::project_id.eq(project_id))
+			.filter(dsl::user_id.eq(leader_id))
+			.execute(&*connection)?;
+		Ok(())
+	}
+
+	fn clear(&self) -> anyhow::Result<()> {
+		let connection = self.0.connection()?;
+		diesel::delete(dsl::project_leads).execute(&*connection)?;
+		Ok(())
+	}
+}

--- a/event-listeners/src/infrastructure/database/project_lead.rs
+++ b/event-listeners/src/infrastructure/database/project_lead.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use crate::{
 	diesel::{ExpressionMethods, QueryDsl, RunQueryDsl},
-	domain::ProjectLead,
+	domain::{ProjectLead, ProjectLeadRepository},
 };
 use infrastructure::database::{schema::project_leads::dsl, Client};
 use uuid::Uuid;
@@ -13,7 +13,9 @@ impl Repository {
 	pub fn new(client: Arc<Client>) -> Self {
 		Self(client)
 	}
+}
 
+impl ProjectLeadRepository for Repository {
 	fn insert(&self, projection: &ProjectLead) -> anyhow::Result<()> {
 		let connection = self.0.connection()?;
 		diesel::insert_into(dsl::project_leads)

--- a/event-listeners/src/presentation/listeners/mod.rs
+++ b/event-listeners/src/presentation/listeners/mod.rs
@@ -32,7 +32,7 @@ pub async fn spawn_all(
 		PaymentRequestProjector::new(payment_request_repository)
 			.spawn(event_bus::consumer("payment_requests").await?),
 		ProjectProjector::new(project_repository, project_lead_repository)
-			.spawn(event_bus::consumer("payment_requests").await?),
+			.spawn(event_bus::consumer("projects").await?),
 	];
 
 	Ok(handles.into())


### PR DESCRIPTION
Will add Cypress tests in a next PR, simulating what Retool does to create projects and assign project leads.