### PR TITLE
fix/amqp

### DIFF
--- a/event-store/src/bus.rs
+++ b/event-store/src/bus.rs
@@ -10,9 +10,15 @@ pub async fn consumer() -> Result<ConsumableBus, BusError> {
 		.with_queue(
 			QUEUE_NAME,
 			QueueDeclareOptions {
-				durable: true,      // persist messages during restart
-				exclusive: true,    // only one consumer on this queue
-				auto_delete: false, // do not delete the queue at shutdown
+				// allows multiple connections to this queue, and do not delete the queue when
+				// connection is closed
+				exclusive: false,
+
+				// the queue will survive a broker restart
+				durable: true,
+
+				// do not delete the queue when the last consumer unsubscribes
+				auto_delete: false,
 				..Default::default()
 			},
 		)

--- a/infrastructure/src/amqp/bus.rs
+++ b/infrastructure/src/amqp/bus.rs
@@ -2,12 +2,14 @@ use lapin::{
 	message::Delivery,
 	options::{ExchangeDeclareOptions, QueueDeclareOptions},
 	publisher_confirm::Confirmation,
-	Channel, Connection, Consumer,
+	BasicProperties, Channel, Connection, Consumer,
 };
 use log::error;
 use thiserror::Error;
 use tokio::sync::RwLock;
 use tokio_stream::StreamExt;
+
+const DELIVERY_MODE_PERSISTENT: u8 = 2;
 
 #[derive(Debug, Error)]
 pub enum Error {
@@ -59,7 +61,7 @@ impl Bus {
 				routing_key,
 				Default::default(),
 				data,
-				Default::default(),
+				BasicProperties::default().with_delivery_mode(DELIVERY_MODE_PERSISTENT),
 			)
 			.await?
 			.await?;

--- a/infrastructure/src/event_bus.rs
+++ b/infrastructure/src/event_bus.rs
@@ -10,9 +10,15 @@ pub async fn consumer(queue_name: &'static str) -> Result<ConsumableBus, BusErro
 		.with_queue(
 			queue_name,
 			QueueDeclareOptions {
-				exclusive: true,    // only one consumer on this queue
-				durable: true,      // persist messages
-				auto_delete: false, // keep the queue during consumer restart
+				// allows multiple connections to this queue, and do not delete the queue when
+				// connection is closed
+				exclusive: false,
+
+				// the queue will survive a broker restart
+				durable: true,
+
+				// do not delete the queue when the last consumer unsubscribes
+				auto_delete: false,
 				..Default::default()
 			},
 		)


### PR DESCRIPTION
- 🐛 fix AMQP config to avoid dropping queues on consumers shutdown
- 🐛 set delivery mode of messages as Persistent so they survive a brocker restart
