### PR TITLE
Remove Hasura buildpack and update metadata at release

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,4 @@
 web: AMQP_ADDR=$CLOUDAMQP_URL ROCKET_PORT=$PORT ./target/release/api
 event-store: AMQP_ADDR=$CLOUDAMQP_URL ./target/release/event-store
 event-listeners: AMQP_ADDR=$CLOUDAMQP_URL WEBSERVER_PORT=$PORT ./target/release/event-listeners
+release: ./hasura/update-metadata.sh

--- a/hasura/update-metadata.sh
+++ b/hasura/update-metadata.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+###########################
+#       Release           #
+###########################
+
+# fail fast
+set -ueo pipefail
+
+export HASURA_GRAPHQL_DISABLE_INTERACTIVE=true
+
+echo "Update metadata"
+
+cd hasura
+./lib/hasura metadata apply


### PR DESCRIPTION
## Problem

Using a buildpack to update metadata is not compatible with Heroku apps lifecycle, because when an app is promoted to production, it is not compiled again.

## Solution

We need to use Heroku's release phase: https://devcenter.heroku.com/articles/release-phase

This phase happens anytime an app is booted up, and is thus what we need in our case.

## Impact

- we can remove the buildpack from the apps
- we can rename the `HASURA_BUILDPACK_GRAPHQL_ENDPOINT` env var to `HASURA_GRAPHQL_ENDPOINT`