### PR TITLE
Spend budget when requesting payment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1210,6 +1210,7 @@ dependencies = [
  "async-std",
  "async-trait",
  "derive-getters",
+ "derive-new",
  "derive_more",
  "diesel",
  "domain",

--- a/api/src/application/payment/request.rs
+++ b/api/src/application/payment/request.rs
@@ -4,8 +4,8 @@ use domain::{
 	specifications::{
 		ProjectExists as ProjectExistsSpecification, UserExists as UserExistsSpecification,
 	},
-	AggregateRootRepository, Event, Payment, PaymentId, Project, ProjectId, Publisher,
-	UniqueMessage, UserId, UserRepository, UuidGenerator,
+	BudgetId, Event, Payment, PaymentId, Publisher, UniqueMessage, UserId, UserRepository,
+	UuidGenerator,
 };
 use serde_json::Value;
 use std::sync::Arc;
@@ -34,7 +34,7 @@ impl Usecase {
 
 	pub async fn request(
 		&self,
-		project_id: ProjectId,
+		budget_id: BudgetId,
 		requestor_id: UserId,
 		recipient_id: UserId,
 		amount_in_usd: u32,
@@ -46,7 +46,7 @@ impl Usecase {
 			&self.project_exists_specification,
 			&self.user_exists_specification,
 			payment_id.into(),
-			project_id,
+			budget_id,
 			requestor_id,
 			recipient_id,
 			amount_in_usd,

--- a/api/src/application/payment/request.rs
+++ b/api/src/application/payment/request.rs
@@ -1,9 +1,11 @@
 use crate::domain::Publishable;
 use anyhow::Result;
 use domain::{
-	specifications::UserExists as UserExistsSpecification, BudgetId, Event, Payment, PaymentId,
-	Publisher, UniqueMessage, UserId, UserRepository, UuidGenerator,
+	specifications::UserExists as UserExistsSpecification, AggregateRootRepository, Budget,
+	BudgetId, Event, Payment, PaymentId, Publisher, UniqueMessage, UserId, UserRepository,
+	UuidGenerator,
 };
+use rusty_money::{crypto, Money};
 use serde_json::Value;
 use std::sync::Arc;
 
@@ -11,6 +13,7 @@ pub struct Usecase {
 	uuid_generator: Arc<dyn UuidGenerator>,
 	event_publisher: Arc<dyn Publisher<UniqueMessage<Event>>>,
 	user_exists_specification: UserExistsSpecification,
+	budget_repository: AggregateRootRepository<Budget>,
 }
 
 impl Usecase {
@@ -18,11 +21,13 @@ impl Usecase {
 		uuid_generator: Arc<dyn UuidGenerator>,
 		event_publisher: Arc<dyn Publisher<UniqueMessage<Event>>>,
 		user_repository: Arc<dyn UserRepository>,
+		budget_repository: AggregateRootRepository<Budget>,
 	) -> Self {
 		Self {
 			uuid_generator,
 			event_publisher,
 			user_exists_specification: UserExistsSpecification::new(user_repository),
+			budget_repository,
 		}
 	}
 
@@ -34,24 +39,32 @@ impl Usecase {
 		amount_in_usd: u32,
 		reason: Value,
 	) -> Result<PaymentId> {
-		let payment_id = self.uuid_generator.new_uuid();
+		let budget = self.budget_repository.find_by_id(&budget_id)?;
+		let mut events = budget
+			.spend(&Money::from_major(amount_in_usd as i64, crypto::USDC).into())?
+			.into_iter()
+			.map(Event::from)
+			.map(UniqueMessage::new)
+			.collect::<Vec<_>>();
 
-		Payment::request(
-			&self.user_exists_specification,
-			payment_id.into(),
-			budget_id,
-			requestor_id,
-			recipient_id,
-			amount_in_usd,
-			reason,
-		)
-		.await?
-		.into_iter()
-		.map(Event::from)
-		.map(UniqueMessage::new)
-		.collect::<Vec<_>>()
-		.publish(self.event_publisher.clone())
-		.await?;
+		let payment_id = self.uuid_generator.new_uuid();
+		events.extend(
+			Payment::request(
+				&self.user_exists_specification,
+				payment_id.into(),
+				budget_id,
+				requestor_id,
+				recipient_id,
+				amount_in_usd,
+				reason,
+			)
+			.await?
+			.into_iter()
+			.map(Event::from)
+			.map(UniqueMessage::new),
+		);
+
+		events.publish(self.event_publisher.clone()).await?;
 
 		Ok(payment_id.into())
 	}

--- a/api/src/application/payment/request.rs
+++ b/api/src/application/payment/request.rs
@@ -1,11 +1,8 @@
 use crate::domain::Publishable;
 use anyhow::Result;
 use domain::{
-	specifications::{
-		ProjectExists as ProjectExistsSpecification, UserExists as UserExistsSpecification,
-	},
-	BudgetId, Event, Payment, PaymentId, Publisher, UniqueMessage, UserId, UserRepository,
-	UuidGenerator,
+	specifications::UserExists as UserExistsSpecification, BudgetId, Event, Payment, PaymentId,
+	Publisher, UniqueMessage, UserId, UserRepository, UuidGenerator,
 };
 use serde_json::Value;
 use std::sync::Arc;
@@ -13,7 +10,6 @@ use std::sync::Arc;
 pub struct Usecase {
 	uuid_generator: Arc<dyn UuidGenerator>,
 	event_publisher: Arc<dyn Publisher<UniqueMessage<Event>>>,
-	project_exists_specification: ProjectExistsSpecification,
 	user_exists_specification: UserExistsSpecification,
 }
 
@@ -21,13 +17,11 @@ impl Usecase {
 	pub fn new(
 		uuid_generator: Arc<dyn UuidGenerator>,
 		event_publisher: Arc<dyn Publisher<UniqueMessage<Event>>>,
-		project_repository: AggregateRootRepository<Project>,
 		user_repository: Arc<dyn UserRepository>,
 	) -> Self {
 		Self {
 			uuid_generator,
 			event_publisher,
-			project_exists_specification: ProjectExistsSpecification::new(project_repository),
 			user_exists_specification: UserExistsSpecification::new(user_repository),
 		}
 	}
@@ -43,7 +37,6 @@ impl Usecase {
 		let payment_id = self.uuid_generator.new_uuid();
 
 		Payment::request(
-			&self.project_exists_specification,
 			&self.user_exists_specification,
 			payment_id.into(),
 			budget_id,

--- a/api/src/domain/project_details/entity.rs
+++ b/api/src/domain/project_details/entity.rs
@@ -19,11 +19,14 @@ use crate::domain::github::GithubRepositoryId;
 	Insertable,
 	Serialize,
 	Deserialize,
+	Queryable,
 	AsChangeset,
 )]
 #[table_name = "project_details"]
 pub struct ProjectDetails {
+	#[diesel(deserialize_as = "uuid::Uuid")]
 	project_id: ProjectId,
+	#[diesel(deserialize_as = "i64")]
 	github_repo_id: GithubRepositoryId,
 	description: Option<String>,
 	telegram_link: Option<String>,

--- a/api/src/graphql/context.rs
+++ b/api/src/graphql/context.rs
@@ -31,7 +31,6 @@ impl Context {
 			request_payment_usecase: application::payment::request::Usecase::new(
 				uuid_generator.to_owned(),
 				event_publisher.to_owned(),
-				project_repository.to_owned(),
 				user_repository,
 			),
 			process_payment_usecase: application::payment::process::Usecase::new(

--- a/api/src/graphql/context.rs
+++ b/api/src/graphql/context.rs
@@ -17,6 +17,7 @@ pub struct Context {
 }
 
 impl Context {
+	#[allow(clippy::too_many_arguments)]
 	pub fn new(
 		user: Box<dyn User>,
 		uuid_generator: Arc<dyn UuidGenerator>,

--- a/api/src/graphql/context.rs
+++ b/api/src/graphql/context.rs
@@ -3,8 +3,8 @@ use crate::{
 	domain::{ProjectDetails, User},
 };
 use domain::{
-	AggregateRootRepository, EntityRepository, Event, Payment, Project, Publisher, UniqueMessage,
-	UserRepository, UuidGenerator,
+	AggregateRootRepository, Budget, EntityRepository, Event, Payment, Project, Publisher,
+	UniqueMessage, UserRepository, UuidGenerator,
 };
 use std::sync::Arc;
 
@@ -23,6 +23,7 @@ impl Context {
 		event_publisher: Arc<dyn Publisher<UniqueMessage<Event>>>,
 		project_repository: AggregateRootRepository<Project>,
 		payment_repository: AggregateRootRepository<Payment>,
+		budget_repository: AggregateRootRepository<Budget>,
 		user_repository: Arc<dyn UserRepository>,
 		project_details_repository: Arc<dyn EntityRepository<ProjectDetails>>,
 	) -> Self {
@@ -32,6 +33,7 @@ impl Context {
 				uuid_generator.to_owned(),
 				event_publisher.to_owned(),
 				user_repository,
+				budget_repository,
 			),
 			process_payment_usecase: application::payment::process::Usecase::new(
 				uuid_generator.to_owned(),

--- a/api/src/graphql/mutation.rs
+++ b/api/src/graphql/mutation.rs
@@ -95,7 +95,7 @@ impl Mutation {
 
 	pub async fn request_payment(
 		context: &Context,
-		project_id: Uuid,
+		budget_id: Uuid,
 		requestor_id: Uuid,
 		recipient_id: Uuid,
 		amount_in_usd: i32,
@@ -110,7 +110,7 @@ impl Mutation {
 		let payment_request_id = context
 			.request_payment_usecase
 			.request(
-				project_id.into(),
+				budget_id.into(),
 				requestor_id.into(),
 				recipient_id.into(),
 				amount_in_usd as u32,

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -8,7 +8,7 @@ mod routes;
 
 use crate::{domain::ProjectDetails, infrastructure::database::ProjectDetailsRepository};
 use ::domain::{
-	AggregateRootRepository, EntityRepository, Event, Payment, Project, Publisher,
+	AggregateRootRepository, Budget, EntityRepository, Event, Payment, Project, Publisher,
 	RandomUuidGenerator, UniqueMessage, UserRepository, UuidGenerator,
 };
 use ::infrastructure::{
@@ -50,6 +50,7 @@ pub async fn main() -> Result<()> {
 		Arc::new(Bus::default().await?),
 		AggregateRootRepository::new(database.clone()),
 		AggregateRootRepository::new(database.clone()),
+		AggregateRootRepository::new(database.clone()),
 		Arc::new(HasuraClient::default()),
 		Arc::new(ProjectDetailsRepository::new(database)),
 	)
@@ -87,6 +88,7 @@ fn inject_app(
 	event_publisher: Arc<dyn Publisher<UniqueMessage<Event>>>,
 	project_repository: AggregateRootRepository<Project>,
 	payment_repository: AggregateRootRepository<Payment>,
+	budget_repository: AggregateRootRepository<Budget>,
 	user_repository: Arc<dyn UserRepository>,
 	project_details_repository: Arc<dyn EntityRepository<ProjectDetails>>,
 ) -> Rocket<Build> {
@@ -96,6 +98,7 @@ fn inject_app(
 		.manage(event_publisher)
 		.manage(project_repository)
 		.manage(payment_repository)
+		.manage(budget_repository)
 		.manage(user_repository)
 		.manage(project_details_repository)
 }

--- a/api/src/routes/graphql.rs
+++ b/api/src/routes/graphql.rs
@@ -4,8 +4,8 @@ use crate::{
 	graphql::{Context, Schema},
 };
 use domain::{
-	AggregateRootRepository, EntityRepository, Event, Payment, Project, Publisher, UniqueMessage,
-	UserRepository, UuidGenerator,
+	AggregateRootRepository, Budget, EntityRepository, Event, Payment, Project, Publisher,
+	UniqueMessage, UserRepository, UuidGenerator,
 };
 use juniper_rocket::{GraphQLRequest, GraphQLResponse};
 use rocket::{response::content, State};
@@ -26,6 +26,7 @@ pub async fn get_graphql_handler(
 	event_publisher: &State<Arc<dyn Publisher<UniqueMessage<Event>>>>,
 	project_repository: &State<AggregateRootRepository<Project>>,
 	payment_repository: &State<AggregateRootRepository<Payment>>,
+	budget_repository: &State<AggregateRootRepository<Budget>>,
 	user_repository: &State<Arc<dyn UserRepository>>,
 	project_details_repository: &State<Arc<dyn EntityRepository<ProjectDetails>>>,
 ) -> GraphQLResponse {
@@ -35,6 +36,7 @@ pub async fn get_graphql_handler(
 		(*event_publisher).clone(),
 		(*project_repository).clone(),
 		(*payment_repository).clone(),
+		(*budget_repository).clone(),
 		(*user_repository).clone(),
 		(*project_details_repository).clone(),
 	);
@@ -51,6 +53,7 @@ pub async fn post_graphql_handler(
 	event_publisher: &State<Arc<dyn Publisher<UniqueMessage<Event>>>>,
 	project_repository: &State<AggregateRootRepository<Project>>,
 	payment_repository: &State<AggregateRootRepository<Payment>>,
+	budget_repository: &State<AggregateRootRepository<Budget>>,
 	user_repository: &State<Arc<dyn UserRepository>>,
 	project_details_repository: &State<Arc<dyn EntityRepository<ProjectDetails>>>,
 ) -> GraphQLResponse {
@@ -60,6 +63,7 @@ pub async fn post_graphql_handler(
 		(*event_publisher).clone(),
 		(*project_repository).clone(),
 		(*payment_repository).clone(),
+		(*budget_repository).clone(),
 		(*user_repository).clone(),
 		(*project_details_repository).clone(),
 	);

--- a/domain/src/budget/aggregate.rs
+++ b/domain/src/budget/aggregate.rs
@@ -1,17 +1,70 @@
-use crate::{Amount, BudgetEvent, BudgetId, BudgetTopic};
+use crate::{Aggregate, AggregateRoot, Amount, BudgetEvent, BudgetId, BudgetTopic, EventSourcable};
+use thiserror::Error;
 
-pub struct Budget;
+#[derive(Debug, Error)]
+pub enum Error {
+	#[error("Not enough budget left")]
+	Overspent,
+	#[error("Invalid currency")]
+	InvalidCurrency,
+}
+
+type Result<T> = std::result::Result<T, Error>;
+
+#[derive(Default)]
+pub struct Budget {
+	id: BudgetId,
+	remaining_amount: Amount,
+}
 
 impl Budget {
 	pub fn allocate(id: BudgetId, topic: BudgetTopic, amount: Amount) -> Vec<BudgetEvent> {
 		vec![BudgetEvent::Allocated { id, topic, amount }]
 	}
+
+	pub fn spend(&self, amount: &Amount) -> Result<Vec<BudgetEvent>> {
+		if self.remaining_amount.currency() != amount.currency() {
+			return Err(Error::InvalidCurrency);
+		}
+
+		if &self.remaining_amount < amount {
+			return Err(Error::Overspent);
+		}
+
+		Ok(vec![BudgetEvent::Spent {
+			id: self.id,
+			amount: amount.clone(),
+		}])
+	}
 }
+
+impl Aggregate for Budget {
+	type Event = BudgetEvent;
+	type Id = BudgetId;
+}
+
+impl EventSourcable for Budget {
+	fn apply_event(self, event: &Self::Event) -> Self {
+		match event {
+			BudgetEvent::Allocated { id, amount, .. } => Self {
+				id: *id,
+				remaining_amount: amount.clone(),
+			},
+			BudgetEvent::Spent { amount, .. } => Self {
+				remaining_amount: self.remaining_amount - amount,
+				..self
+			},
+		}
+	}
+}
+
+impl AggregateRoot for Budget {}
 
 #[cfg(test)]
 mod tests {
 	use super::*;
 	use crate::ProjectId;
+	use assert_matches::assert_matches;
 	use rstest::*;
 	use rust_decimal_macros::dec;
 	use uuid::Uuid;
@@ -51,6 +104,14 @@ mod tests {
 		}
 	}
 
+	#[fixture]
+	fn budget_spent_event(budget_id: &BudgetId, amount: Amount) -> BudgetEvent {
+		BudgetEvent::Spent {
+			id: *budget_id,
+			amount,
+		}
+	}
+
 	#[rstest]
 	fn allocate_budget_for_project(
 		budget_id: &BudgetId,
@@ -62,5 +123,35 @@ mod tests {
 			Budget::allocate(*budget_id, topic, amount),
 			vec![budget_allocated_event]
 		);
+	}
+
+	#[rstest]
+	fn spend_budget(
+		amount: Amount,
+		budget_allocated_event: BudgetEvent,
+		budget_spent_event: BudgetEvent,
+	) {
+		let budget = Budget::from_events(&[budget_allocated_event]);
+		let result = budget.spend(&amount);
+		assert!(result.is_ok(), "{}", result.err().unwrap());
+		let events = result.unwrap();
+		assert_eq!(events, vec![budget_spent_event]);
+	}
+
+	#[rstest]
+	fn overspend_budget(amount: Amount, budget_allocated_event: BudgetEvent) {
+		let budget = Budget::from_events(&[budget_allocated_event]);
+		let result = budget.spend(&(amount * 2));
+		assert_matches!(result, Err(Error::Overspent));
+	}
+
+	#[rstest]
+	fn spend_in_different_currency(budget_allocated_event: BudgetEvent) {
+		let budget = Budget::from_events(&[budget_allocated_event]);
+		let result = budget.spend(&Amount::new(
+			dec!(10),
+			crate::Currency::Crypto("USDT".to_string()),
+		));
+		assert_matches!(result, Err(Error::InvalidCurrency));
 	}
 }

--- a/domain/src/budget/aggregate.rs
+++ b/domain/src/budget/aggregate.rs
@@ -11,7 +11,7 @@ pub enum Error {
 
 type Result<T> = std::result::Result<T, Error>;
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct Budget {
 	id: BudgetId,
 	remaining_amount: Amount,

--- a/domain/src/budget/events.rs
+++ b/domain/src/budget/events.rs
@@ -1,5 +1,6 @@
 use crate::{Amount, BudgetId, BudgetTopic};
 use serde::{Deserialize, Serialize};
+use std::fmt::Display;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum Event {
@@ -8,11 +9,25 @@ pub enum Event {
 		topic: BudgetTopic,
 		amount: Amount,
 	},
+	Spent {
+		id: BudgetId,
+		amount: Amount,
+	},
 }
 
 impl From<Event> for crate::Event {
 	fn from(event: Event) -> Self {
 		Self::Budget(event)
+	}
+}
+
+impl Display for Event {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		write!(
+			f,
+			"{}",
+			serde_json::to_string(&self).map_err(|_| std::fmt::Error)?
+		)
 	}
 }
 

--- a/domain/src/entity.rs
+++ b/domain/src/entity.rs
@@ -4,6 +4,7 @@ pub trait Entity {
 
 use anyhow::Result;
 pub trait Repository<E: Entity>: Send + Sync {
+	fn find_by_id(&self, id: &E::Id) -> Result<E>;
 	fn insert(&self, entity: &E) -> Result<()>;
 	fn update(&self, id: &E::Id, entity: &E) -> Result<()>;
 	fn upsert(&self, entity: &E) -> Result<()>;

--- a/domain/src/payment/aggregate.rs
+++ b/domain/src/payment/aggregate.rs
@@ -1,8 +1,8 @@
 #[cfg_attr(test, mockall_double::double)]
 use crate::specifications::{ProjectExists, UserExists};
 use crate::{
-	specifications, Aggregate, AggregateRoot, Amount, EventSourcable, PaymentEvent, PaymentId,
-	PaymentReceipt, PaymentReceiptId, ProjectId, UserId,
+	specifications, Aggregate, AggregateRoot, Amount, BudgetId, EventSourcable, PaymentEvent,
+	PaymentId, PaymentReceipt, PaymentReceiptId, UserId,
 };
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
@@ -62,7 +62,7 @@ impl Payment {
 		project_exists_specification: &ProjectExists,
 		user_exists_specification: &UserExists,
 		id: PaymentId,
-		project_id: ProjectId,
+		budget_id: BudgetId,
 		requestor_id: UserId,
 		recipient_id: UserId,
 		amount_in_usd: u32,
@@ -93,7 +93,7 @@ impl Payment {
 
 		Ok(vec![PaymentEvent::Requested {
 			id,
-			project_id,
+			budget_id,
 			requestor_id,
 			recipient_id,
 			amount_in_usd,
@@ -135,7 +135,7 @@ mod tests {
 	use super::*;
 	#[mockall_double::double]
 	use crate::specifications::ProjectExists;
-	use crate::{BlockchainNetwork, Currency, PaymentReceiptId, ProjectId, UserId};
+	use crate::{BlockchainNetwork, BudgetId, Currency, PaymentReceiptId, UserId};
 	use assert_matches::assert_matches;
 	use mockall::predicate::*;
 	use rstest::{fixture, rstest};
@@ -149,7 +149,7 @@ mod tests {
 	}
 
 	#[fixture]
-	fn project_id() -> ProjectId {
+	fn budget_id() -> BudgetId {
 		Uuid::from_str("11111111-aaaa-495e-9f4c-038ec0ebecb1").unwrap().into()
 	}
 
@@ -228,7 +228,7 @@ mod tests {
 	#[fixture]
 	async fn requested_payment(
 		payment_id: PaymentId,
-		project_id: ProjectId,
+		budget_id: BudgetId,
 		requestor_id: UserId,
 		recipient_id: UserId,
 		amount_in_usd: u32,
@@ -243,7 +243,7 @@ mod tests {
 			&project_exists,
 			&user_exists,
 			payment_id,
-			project_id,
+			budget_id,
 			requestor_id,
 			recipient_id,
 			amount_in_usd,
@@ -307,7 +307,7 @@ mod tests {
 	#[rstest]
 	async fn test_request(
 		payment_id: PaymentId,
-		project_id: ProjectId,
+		budget_id: BudgetId,
 		requestor_id: UserId,
 		recipient_id: UserId,
 		amount_in_usd: u32,
@@ -336,7 +336,7 @@ mod tests {
 			&project_exists_specification,
 			&user_exists_specification,
 			payment_id,
-			project_id,
+			budget_id,
 			requestor_id,
 			recipient_id,
 			amount_in_usd,
@@ -350,7 +350,7 @@ mod tests {
 			events[0],
 			PaymentEvent::Requested {
 				id: payment_id,
-				project_id,
+				budget_id,
 				requestor_id,
 				recipient_id,
 				amount_in_usd,
@@ -396,7 +396,7 @@ mod tests {
 	#[rstest]
 	async fn test_request_with_wrong_requestor_id(
 		payment_id: PaymentId,
-		project_id: ProjectId,
+		budget_id: BudgetId,
 		wrong_requestor_id: UserId,
 		recipient_id: UserId,
 		amount_in_usd: u32,
@@ -420,7 +420,7 @@ mod tests {
 			&project_exists_specification,
 			&user_exists_specification,
 			payment_id,
-			project_id,
+			budget_id,
 			wrong_requestor_id,
 			recipient_id,
 			amount_in_usd,
@@ -435,7 +435,7 @@ mod tests {
 	#[rstest]
 	async fn test_request_with_wrong_recipient_id(
 		payment_id: PaymentId,
-		project_id: ProjectId,
+		budget_id: BudgetId,
 		requestor_id: UserId,
 		wrong_recipient_id: UserId,
 		amount_in_usd: u32,
@@ -464,7 +464,7 @@ mod tests {
 			&project_exists_specification,
 			&user_exists_specification,
 			payment_id,
-			project_id,
+			budget_id,
 			requestor_id,
 			wrong_recipient_id,
 			amount_in_usd,
@@ -480,7 +480,7 @@ mod tests {
 	fn test_event_sourced(payment_id: PaymentId) {
 		let event = PaymentEvent::Requested {
 			id: payment_id,
-			project_id: Default::default(),
+			budget_id: Default::default(),
 			requestor_id: Default::default(),
 			recipient_id: Default::default(),
 			amount_in_usd: Default::default(),

--- a/domain/src/payment/events.rs
+++ b/domain/src/payment/events.rs
@@ -1,4 +1,4 @@
-use crate::{Amount, PaymentId, PaymentReceipt, PaymentReceiptId, ProjectId, UserId};
+use crate::{Amount, BudgetId, PaymentId, PaymentReceipt, PaymentReceiptId, UserId};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::fmt::Display;
@@ -7,7 +7,7 @@ use std::fmt::Display;
 pub enum Event {
 	Requested {
 		id: PaymentId,
-		project_id: ProjectId,
+		budget_id: BudgetId,
 		requestor_id: UserId,
 		recipient_id: UserId,
 		amount_in_usd: u32,

--- a/domain/src/value_objects/amount.rs
+++ b/domain/src/value_objects/amount.rs
@@ -1,18 +1,60 @@
+use std::ops::{Mul, Sub};
+
 use derive_getters::Getters;
 use derive_more::Display;
 use rust_decimal::Decimal;
 use rusty_money::{FormattableCurrency, Money};
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Getters)]
+#[derive(
+	Debug, Default, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, Getters,
+)]
 pub struct Amount {
 	amount: Decimal,
 	currency: Currency,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Display)]
+impl ToString for Amount {
+	fn to_string(&self) -> String {
+		format!("{} {}", self.amount, self.currency)
+	}
+}
+
+impl Sub<&Self> for Amount {
+	type Output = Self;
+
+	fn sub(self, rhs: &Self) -> Self::Output {
+		assert_eq!(
+			self.currency, rhs.currency,
+			"Cannot substract with different currencies"
+		);
+		Self {
+			amount: self.amount - rhs.amount,
+			..self
+		}
+	}
+}
+
+impl Mul<i64> for Amount {
+	type Output = Self;
+
+	fn mul(self, rhs: i64) -> Self::Output {
+		Self {
+			amount: self.amount * Decimal::new(rhs, 0),
+			..self
+		}
+	}
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, Display)]
 pub enum Currency {
 	Crypto(String),
+}
+
+impl Default for Currency {
+	fn default() -> Self {
+		Self::Crypto(Default::default())
+	}
 }
 
 impl Amount {
@@ -42,5 +84,23 @@ mod tests {
 			Amount::new(dec!(125), Currency::Crypto("USDC".to_string())),
 			Money::from_major(125, crypto::USDC).into()
 		);
+	}
+
+	#[test]
+	fn substract() {
+		let amount1 = Amount::new(dec!(125), Currency::Crypto("USDC".to_string()));
+		let amount2 = Amount::new(dec!(5), Currency::Crypto("USDC".to_string()));
+		assert_eq!(
+			Amount::new(dec!(120), Currency::Crypto("USDC".to_string())),
+			amount1 - &amount2
+		);
+	}
+
+	#[test]
+	#[should_panic = "Cannot substract with different currencies"]
+	fn substract_different_currencies() {
+		let amount1 = Amount::new(dec!(125), Currency::Crypto("USDC".to_string()));
+		let amount2 = Amount::new(dec!(5), Currency::Crypto("USDT".to_string()));
+		let _ = amount1 - &amount2;
 	}
 }

--- a/event-listeners/Cargo.toml
+++ b/event-listeners/Cargo.toml
@@ -54,6 +54,7 @@ serde_json = {version = "1.0.81"}
 # Utils
 derive-getters = "0.2.0"
 derive_more = "0.99.17"
+derive-new = "0.5.9"
 dotenv = "0.15.0"
 
 # Local dependecies

--- a/event-listeners/src/domain/projections/budget.rs
+++ b/event-listeners/src/domain/projections/budget.rs
@@ -1,0 +1,16 @@
+use super::Projection;
+use infrastructure::database::schema::budgets;
+use rust_decimal::Decimal;
+use uuid::Uuid;
+
+#[derive(Debug, Insertable, Identifiable, AsChangeset, new)]
+pub struct Budget {
+	id: Uuid,
+	project_id: Uuid,
+	initial_amount: Decimal,
+	remaining_amount: Decimal,
+}
+
+impl Projection for Budget {
+	type Id = Uuid;
+}

--- a/event-listeners/src/domain/projections/budget.rs
+++ b/event-listeners/src/domain/projections/budget.rs
@@ -9,7 +9,7 @@ pub struct Budget {
 	id: Uuid,
 	project_id: Option<Uuid>,
 	initial_amount: Decimal,
-	remaining_amount: Decimal,
+	pub remaining_amount: Decimal,
 }
 
 impl Entity for Budget {

--- a/event-listeners/src/domain/projections/budget.rs
+++ b/event-listeners/src/domain/projections/budget.rs
@@ -1,16 +1,19 @@
 use super::Projection;
+use domain::Entity;
 use infrastructure::database::schema::budgets;
 use rust_decimal::Decimal;
 use uuid::Uuid;
 
-#[derive(Debug, Insertable, Identifiable, AsChangeset, new)]
+#[derive(Debug, Insertable, Identifiable, Queryable, AsChangeset, new)]
 pub struct Budget {
 	id: Uuid,
-	project_id: Uuid,
+	project_id: Option<Uuid>,
 	initial_amount: Decimal,
 	remaining_amount: Decimal,
 }
 
-impl Projection for Budget {
+impl Entity for Budget {
 	type Id = Uuid;
 }
+
+impl Projection for Budget {}

--- a/event-listeners/src/domain/projections/mod.rs
+++ b/event-listeners/src/domain/projections/mod.rs
@@ -1,4 +1,6 @@
 #[allow(clippy::extra_unused_lifetimes)]
+mod budget;
+#[allow(clippy::extra_unused_lifetimes)]
 mod payment;
 #[allow(clippy::extra_unused_lifetimes)]
 mod payment_request;
@@ -7,6 +9,7 @@ mod project;
 #[allow(clippy::extra_unused_lifetimes)]
 mod project_lead;
 
+pub use budget::Budget;
 use domain::Entity;
 pub use payment::Payment;
 pub use payment_request::PaymentRequest;

--- a/event-listeners/src/domain/projections/payment.rs
+++ b/event-listeners/src/domain/projections/payment.rs
@@ -5,31 +5,13 @@ use rust_decimal::Decimal;
 use serde_json::Value;
 use uuid::Uuid;
 
-#[derive(Debug, Insertable, Identifiable, AsChangeset)]
+#[derive(Debug, Insertable, Identifiable, AsChangeset, new)]
 pub struct Payment {
 	id: Uuid,
 	amount: Decimal,
 	currency_code: String,
 	receipt: Value,
 	request_id: Uuid,
-}
-
-impl Payment {
-	pub fn new(
-		id: Uuid,
-		amount: Decimal,
-		currency_code: String,
-		receipt: Value,
-		request_id: Uuid,
-	) -> Self {
-		Self {
-			id,
-			amount,
-			currency_code,
-			receipt,
-			request_id,
-		}
-	}
 }
 
 impl Entity for Payment {

--- a/event-listeners/src/domain/projections/payment.rs
+++ b/event-listeners/src/domain/projections/payment.rs
@@ -5,7 +5,7 @@ use rust_decimal::Decimal;
 use serde_json::Value;
 use uuid::Uuid;
 
-#[derive(Debug, Insertable, Identifiable, AsChangeset, new)]
+#[derive(Debug, Insertable, Identifiable, Queryable, AsChangeset, new)]
 pub struct Payment {
 	id: Uuid,
 	amount: Decimal,

--- a/event-listeners/src/domain/projections/payment_request.rs
+++ b/event-listeners/src/domain/projections/payment_request.rs
@@ -7,7 +7,7 @@ use uuid::Uuid;
 #[derive(Debug, Insertable, Identifiable, Queryable, AsChangeset, new)]
 pub struct PaymentRequest {
 	id: Uuid,
-	project_id: Uuid,
+	budget_id: Uuid,
 	requestor_id: Uuid,
 	recipient_id: Uuid,
 	amount_in_usd: i64,

--- a/event-listeners/src/domain/projections/payment_request.rs
+++ b/event-listeners/src/domain/projections/payment_request.rs
@@ -4,7 +4,7 @@ use infrastructure::database::schema::payment_requests;
 use serde_json::Value;
 use uuid::Uuid;
 
-#[derive(Debug, Insertable, Identifiable, AsChangeset, new)]
+#[derive(Debug, Insertable, Identifiable, Queryable, AsChangeset, new)]
 pub struct PaymentRequest {
 	id: Uuid,
 	project_id: Uuid,

--- a/event-listeners/src/domain/projections/payment_request.rs
+++ b/event-listeners/src/domain/projections/payment_request.rs
@@ -4,7 +4,7 @@ use infrastructure::database::schema::payment_requests;
 use serde_json::Value;
 use uuid::Uuid;
 
-#[derive(Debug, Insertable, Identifiable, AsChangeset)]
+#[derive(Debug, Insertable, Identifiable, AsChangeset, new)]
 pub struct PaymentRequest {
 	id: Uuid,
 	project_id: Uuid,
@@ -12,26 +12,6 @@ pub struct PaymentRequest {
 	recipient_id: Uuid,
 	amount_in_usd: i64,
 	reason: Value,
-}
-
-impl PaymentRequest {
-	pub fn new(
-		id: Uuid,
-		project_id: Uuid,
-		requestor_id: Uuid,
-		recipient_id: Uuid,
-		amount_in_usd: i64,
-		reason: Value,
-	) -> Self {
-		Self {
-			id,
-			project_id,
-			requestor_id,
-			recipient_id,
-			amount_in_usd,
-			reason,
-		}
-	}
 }
 
 impl Entity for PaymentRequest {

--- a/event-listeners/src/domain/projections/project.rs
+++ b/event-listeners/src/domain/projections/project.rs
@@ -3,16 +3,10 @@ use domain::Entity;
 use infrastructure::database::schema::projects;
 use uuid::Uuid;
 
-#[derive(Debug, Insertable, Identifiable, AsChangeset)]
+#[derive(Debug, Insertable, Identifiable, AsChangeset, new)]
 pub struct Project {
 	id: Uuid,
 	name: String,
-}
-
-impl Project {
-	pub fn new(id: Uuid, name: String) -> Self {
-		Self { id, name }
-	}
 }
 
 impl Entity for Project {

--- a/event-listeners/src/domain/projections/project.rs
+++ b/event-listeners/src/domain/projections/project.rs
@@ -3,7 +3,7 @@ use domain::Entity;
 use infrastructure::database::schema::projects;
 use uuid::Uuid;
 
-#[derive(Debug, Insertable, Identifiable, AsChangeset, new)]
+#[derive(Debug, Insertable, Identifiable, Queryable, AsChangeset, new)]
 pub struct Project {
 	id: Uuid,
 	name: String,

--- a/event-listeners/src/domain/projections/project_lead.rs
+++ b/event-listeners/src/domain/projections/project_lead.rs
@@ -4,20 +4,11 @@ use domain::Entity;
 use infrastructure::database::schema::project_leads;
 use uuid::Uuid;
 
-#[derive(Debug, Insertable, Identifiable)]
+#[derive(Debug, Insertable, Identifiable, new)]
 #[primary_key(project_id, user_id)]
 pub struct ProjectLead {
 	project_id: Uuid,
 	user_id: Uuid,
-}
-
-impl ProjectLead {
-	pub fn new(project_id: Uuid, user_id: Uuid) -> Self {
-		Self {
-			project_id,
-			user_id,
-		}
-	}
 }
 
 impl Entity for ProjectLead {

--- a/event-listeners/src/domain/projectors/budget.rs
+++ b/event-listeners/src/domain/projectors/budget.rs
@@ -1,0 +1,30 @@
+use crate::domain::{Budget, EventListener, ProjectionRepository};
+use anyhow::Result;
+use async_trait::async_trait;
+use domain::{BudgetEvent, BudgetTopic, Event};
+use std::sync::Arc;
+
+#[derive(new)]
+pub struct Projector {
+	budget_repository: Arc<dyn ProjectionRepository<Budget>>,
+}
+
+#[async_trait]
+impl EventListener for Projector {
+	async fn on_event(&self, event: &Event) -> Result<()> {
+		if let Event::Budget(event) = event {
+			match event {
+				BudgetEvent::Allocated { id, amount, topic } => {
+					let BudgetTopic::Project(project_id) = topic;
+					self.budget_repository.insert(&Budget::new(
+						(*id).into(),
+						(*project_id).into(),
+						*amount.amount(),
+						*amount.amount(),
+					))?;
+				},
+			}
+		}
+		Ok(())
+	}
+}

--- a/event-listeners/src/domain/projectors/budget.rs
+++ b/event-listeners/src/domain/projectors/budget.rs
@@ -1,12 +1,12 @@
-use crate::domain::{Budget, EventListener, ProjectionRepository};
+use crate::domain::{Budget, EventListener};
 use anyhow::Result;
 use async_trait::async_trait;
-use domain::{BudgetEvent, BudgetTopic, Event};
+use domain::{BudgetEvent, BudgetTopic, EntityRepository, Event};
 use std::sync::Arc;
 
 #[derive(new)]
 pub struct Projector {
-	budget_repository: Arc<dyn ProjectionRepository<Budget>>,
+	budget_repository: Arc<dyn EntityRepository<Budget>>,
 }
 
 #[async_trait]
@@ -18,7 +18,7 @@ impl EventListener for Projector {
 					let BudgetTopic::Project(project_id) = topic;
 					self.budget_repository.insert(&Budget::new(
 						(*id).into(),
-						(*project_id).into(),
+						Some((*project_id).into()),
 						*amount.amount(),
 						*amount.amount(),
 					))?;

--- a/event-listeners/src/domain/projectors/budget.rs
+++ b/event-listeners/src/domain/projectors/budget.rs
@@ -23,6 +23,12 @@ impl EventListener for Projector {
 						*amount.amount(),
 					))?;
 				},
+				BudgetEvent::Spent { id, amount } => {
+					let id = (*id).into();
+					let mut budget = self.budget_repository.find_by_id(&id)?;
+					budget.remaining_amount -= amount.amount();
+					self.budget_repository.update(&id, &budget)?;
+				},
 			}
 		}
 		Ok(())

--- a/event-listeners/src/domain/projectors/mod.rs
+++ b/event-listeners/src/domain/projectors/mod.rs
@@ -1,9 +1,9 @@
+mod budget;
 mod payment;
 mod payment_request;
 mod project;
-mod budget;
 
+pub use budget::Projector as BudgetProjector;
 pub use payment::Projector as PaymentProjector;
 pub use payment_request::Projector as PaymentRequestProjector;
 pub use project::Projector as ProjectProjector;
-pub use budget::Projector as BudgetProjector;

--- a/event-listeners/src/domain/projectors/mod.rs
+++ b/event-listeners/src/domain/projectors/mod.rs
@@ -1,7 +1,9 @@
 mod payment;
 mod payment_request;
 mod project;
+mod budget;
 
 pub use payment::Projector as PaymentProjector;
 pub use payment_request::Projector as PaymentRequestProjector;
 pub use project::Projector as ProjectProjector;
+pub use budget::Projector as BudgetProjector;

--- a/event-listeners/src/domain/projectors/payment_request.rs
+++ b/event-listeners/src/domain/projectors/payment_request.rs
@@ -19,7 +19,7 @@ impl EventListener for Projector {
 	async fn on_event(&self, event: &Event) -> Result<()> {
 		if let Event::Payment(PaymentEvent::Requested {
 			id,
-			project_id,
+			budget_id,
 			requestor_id,
 			recipient_id,
 			amount_in_usd,
@@ -28,7 +28,7 @@ impl EventListener for Projector {
 		{
 			self.repository.insert(&PaymentRequest::new(
 				(*id).into(),
-				(*project_id).into(),
+				(*budget_id).into(),
 				(*requestor_id).into(),
 				(*recipient_id).into(),
 				*amount_in_usd as i64,

--- a/event-listeners/src/infrastructure/database/budget.rs
+++ b/event-listeners/src/infrastructure/database/budget.rs
@@ -1,0 +1,9 @@
+use crate::domain::Budget;
+use infrastructure::database::{schema::budgets::dsl, Client};
+use std::sync::Arc;
+
+#[derive(DieselRepository, new)]
+#[projection(Budget)]
+#[table(dsl::budgets)]
+#[id(dsl::id)]
+pub struct Repository(Arc<Client>);

--- a/event-listeners/src/infrastructure/database/budget.rs
+++ b/event-listeners/src/infrastructure/database/budget.rs
@@ -3,7 +3,7 @@ use infrastructure::database::{schema::budgets::dsl, Client};
 use std::sync::Arc;
 
 #[derive(DieselRepository, new)]
-#[projection(Budget)]
+#[entity(Budget)]
 #[table(dsl::budgets)]
 #[id(dsl::id)]
 pub struct Repository(Arc<Client>);

--- a/event-listeners/src/infrastructure/database/mod.rs
+++ b/event-listeners/src/infrastructure/database/mod.rs
@@ -1,8 +1,10 @@
+mod budget;
 mod payment;
 mod payment_request;
 mod project;
 mod project_lead;
 
+pub use budget::Repository as BudgetRepository;
 pub use payment::Repository as PaymentRepository;
 pub use payment_request::Repository as PaymentRequestRepository;
 pub use project::Repository as ProjectRepository;

--- a/event-listeners/src/infrastructure/database/payment.rs
+++ b/event-listeners/src/infrastructure/database/payment.rs
@@ -3,17 +3,11 @@ use std::sync::Arc;
 use crate::domain::Payment;
 use infrastructure::database::{schema::payments::dsl, Client};
 
-#[derive(DieselRepository)]
+#[derive(DieselRepository, new)]
 #[entity(Payment)]
 #[table(dsl::payments)]
 #[id(dsl::id)]
 pub struct Repository(Arc<Client>);
-
-impl Repository {
-	pub fn new(client: Arc<Client>) -> Self {
-		Self(client)
-	}
-}
 
 #[cfg(test)]
 mod tests {

--- a/event-listeners/src/infrastructure/database/payment_request.rs
+++ b/event-listeners/src/infrastructure/database/payment_request.rs
@@ -2,14 +2,8 @@ use crate::domain::PaymentRequest;
 use infrastructure::database::{schema::payment_requests::dsl, Client};
 use std::sync::Arc;
 
-#[derive(DieselRepository)]
+#[derive(DieselRepository, new)]
 #[entity(PaymentRequest)]
 #[table(dsl::payment_requests)]
 #[id(dsl::id)]
 pub struct Repository(Arc<Client>);
-
-impl Repository {
-	pub fn new(client: Arc<Client>) -> Self {
-		Self(client)
-	}
-}

--- a/event-listeners/src/infrastructure/database/project.rs
+++ b/event-listeners/src/infrastructure/database/project.rs
@@ -3,14 +3,8 @@ use std::sync::Arc;
 use crate::domain::Project;
 use infrastructure::database::{schema::projects::dsl, Client};
 
-#[derive(DieselRepository)]
+#[derive(DieselRepository, new)]
 #[entity(Project)]
 #[table(dsl::projects)]
 #[id(dsl::id)]
 pub struct Repository(Arc<Client>);
-
-impl Repository {
-	pub fn new(client: Arc<Client>) -> Self {
-		Self(client)
-	}
-}

--- a/event-listeners/src/infrastructure/database/project_lead.rs
+++ b/event-listeners/src/infrastructure/database/project_lead.rs
@@ -7,13 +7,8 @@ use crate::{
 use infrastructure::database::{schema::project_leads::dsl, Client};
 use uuid::Uuid;
 
+#[derive(new)]
 pub struct Repository(Arc<Client>);
-
-impl Repository {
-	pub fn new(client: Arc<Client>) -> Self {
-		Self(client)
-	}
-}
 
 impl ProjectLeadRepository for Repository {
 	fn insert(&self, projection: &ProjectLead) -> anyhow::Result<()> {

--- a/event-listeners/src/lib.rs
+++ b/event-listeners/src/lib.rs
@@ -4,6 +4,9 @@ extern crate diesel;
 #[macro_use]
 extern crate macros;
 
+#[macro_use]
+extern crate derive_new;
+
 use std::sync::Arc;
 
 use ::infrastructure::database;

--- a/event-listeners/src/presentation/listeners/mod.rs
+++ b/event-listeners/src/presentation/listeners/mod.rs
@@ -7,7 +7,8 @@ use webhook::EventWebHook;
 use crate::{
 	domain::*,
 	infrastructure::database::{
-		PaymentRepository, PaymentRequestRepository, ProjectLeadRepository, ProjectRepository,
+		BudgetRepository, PaymentRepository, PaymentRequestRepository, ProjectLeadRepository,
+		ProjectRepository,
 	},
 };
 use anyhow::Result;
@@ -23,6 +24,7 @@ pub async fn spawn_all(
 	let payment_repository = Arc::new(PaymentRepository::new(database.clone()));
 	let payment_request_repository = Arc::new(PaymentRequestRepository::new(database.clone()));
 	let project_repository = Arc::new(ProjectRepository::new(database.clone()));
+	let budget_repository = Arc::new(BudgetRepository::new(database.clone()));
 	let project_lead_repository = Arc::new(ProjectLeadRepository::new(database));
 
 	let handles = [
@@ -33,6 +35,7 @@ pub async fn spawn_all(
 			.spawn(event_bus::consumer("payment_requests").await?),
 		ProjectProjector::new(project_repository, project_lead_repository)
 			.spawn(event_bus::consumer("projects").await?),
+		BudgetProjector::new(budget_repository).spawn(event_bus::consumer("budgets").await?),
 	];
 
 	Ok(handles.into())

--- a/event-store/src/lib.rs
+++ b/event-store/src/lib.rs
@@ -72,7 +72,8 @@ impl IdentifiableAggregate for Event {
 				| backend_domain::PaymentEvent::Processed { id, .. } => id.to_string(),
 			},
 			Event::Budget(event) => match event {
-				backend_domain::BudgetEvent::Allocated { id, .. } => id.to_string(),
+				backend_domain::BudgetEvent::Allocated { id, .. }
+				| backend_domain::BudgetEvent::Spent { id, .. } => id.to_string(),
 			},
 		}
 	}

--- a/hasura/metadata/databases/default/tables/public_budgets.yaml
+++ b/hasura/metadata/databases/default/tables/public_budgets.yaml
@@ -1,0 +1,24 @@
+table:
+  name: budgets
+  schema: public
+object_relationships:
+  - name: project
+    using:
+      manual_configuration:
+        column_mapping:
+          project_id: id
+        insertion_order: null
+        remote_table:
+          name: projects
+          schema: public
+select_permissions:
+  - role: public
+    permission:
+      columns:
+        - id
+        - project_id
+        - initial_amount
+        - remaining_amount
+      filter:
+        project_id:
+          _in: X-Hasura-projects_leaded

--- a/hasura/metadata/databases/default/tables/public_payment_requests.yaml
+++ b/hasura/metadata/databases/default/tables/public_payment_requests.yaml
@@ -2,18 +2,14 @@ table:
   name: payment_requests
   schema: public
 object_relationships:
-  - name: project
-    using:
-      foreign_key_constraint_on: project_id
-  - name: project_lead
+  - name: budget
     using:
       manual_configuration:
         column_mapping:
-          project_id: project_id
-          requestor_id: user_id
+          budget_id: id
         insertion_order: null
         remote_table:
-          name: project_leads
+          name: budgets
           schema: public
   - name: recipient
     using:
@@ -41,35 +37,3 @@ array_relationships:
         table:
           name: payments
           schema: public
-insert_permissions:
-  - role: user
-    permission:
-      check:
-        project_id:
-          _in: X-Hasura-projects_leaded
-      set:
-        requestor_id: x-hasura-User-id
-      columns:
-        - amount_in_usd
-        - project_id
-        - reason
-        - recipient_id
-select_permissions:
-  - role: user
-    permission:
-      columns:
-        - amount_in_usd
-        - reason
-        - id
-        - project_id
-        - recipient_id
-        - requestor_id
-      filter:
-        project_id:
-          _in: X-Hasura-projects_leaded
-delete_permissions:
-  - role: user
-    permission:
-      filter:
-        project_id:
-          _in: X-Hasura-projects_leaded

--- a/hasura/metadata/databases/default/tables/public_project_leads.yaml
+++ b/hasura/metadata/databases/default/tables/public_project_leads.yaml
@@ -14,17 +14,6 @@ object_relationships:
         remote_table:
           name: users
           schema: auth
-array_relationships:
-  - name: payment_requests
-    using:
-      manual_configuration:
-        column_mapping:
-          project_id: project_id
-          user_id: requestor_id
-        insertion_order: null
-        remote_table:
-          name: payment_requests
-          schema: public
 select_permissions:
   - role: public
     permission:

--- a/hasura/metadata/databases/default/tables/public_projects.yaml
+++ b/hasura/metadata/databases/default/tables/public_projects.yaml
@@ -21,13 +21,6 @@ array_relationships:
         remote_table:
           name: budgets
           schema: public
-  - name: payment_requests
-    using:
-      foreign_key_constraint_on:
-        column: project_id
-        table:
-          name: payment_requests
-          schema: public
   - name: project_leads
     using:
       foreign_key_constraint_on:

--- a/hasura/metadata/databases/default/tables/public_projects.yaml
+++ b/hasura/metadata/databases/default/tables/public_projects.yaml
@@ -12,6 +12,15 @@ object_relationships:
           name: project_details
           schema: public
 array_relationships:
+  - name: budgets
+    using:
+      manual_configuration:
+        column_mapping:
+          id: project_id
+        insertion_order: null
+        remote_table:
+          name: budgets
+          schema: public
   - name: payment_requests
     using:
       foreign_key_constraint_on:

--- a/hasura/metadata/databases/default/tables/tables.yaml
+++ b/hasura/metadata/databases/default/tables/tables.yaml
@@ -6,6 +6,7 @@
 - "!include auth_user_roles.yaml"
 - "!include auth_user_security_keys.yaml"
 - "!include auth_users.yaml"
+- "!include public_budgets.yaml"
 - "!include public_payment_requests.yaml"
 - "!include public_payments.yaml"
 - "!include public_payout_settings.yaml"

--- a/hasura/metadata/remote_schemas.yaml
+++ b/hasura/metadata/remote_schemas.yaml
@@ -13,7 +13,7 @@
           }
           scalar Uuid
           type Mutation {
-            requestPayment(projectId: Uuid!, requestorId: Uuid!, recipientId: Uuid!, amountInUsd: Int!, reason: String!): Uuid!
+            requestPayment(budgetId: Uuid!, requestorId: Uuid!, recipientId: Uuid!, amountInUsd: Int!, reason: String!): Uuid!
           }
           type Query {
             hello: String!

--- a/infrastructure/src/database/schema.rs
+++ b/infrastructure/src/database/schema.rs
@@ -1,6 +1,15 @@
 // @generated automatically by Diesel CLI.
 
 diesel::table! {
+    budgets (id) {
+        id -> Uuid,
+        project_id -> Nullable<Uuid>,
+        initial_amount -> Numeric,
+        remaining_amount -> Numeric,
+    }
+}
+
+diesel::table! {
     event_deduplications (deduplication_id) {
         deduplication_id -> Text,
         event_index -> Int4,
@@ -83,11 +92,13 @@ diesel::table! {
     }
 }
 
+diesel::joinable!(budgets -> projects (project_id));
 diesel::joinable!(payment_requests -> projects (project_id));
 diesel::joinable!(payments -> payment_requests (request_id));
 diesel::joinable!(project_leads -> projects (project_id));
 
 diesel::allow_tables_to_appear_in_same_query!(
+    budgets,
     event_deduplications,
     event_filters,
     events,

--- a/infrastructure/src/database/schema.rs
+++ b/infrastructure/src/database/schema.rs
@@ -58,7 +58,7 @@ diesel::table! {
         amount -> Numeric,
         currency_code -> Text,
         receipt -> Jsonb,
-        request_id -> Nullable<Uuid>,
+        request_id -> Uuid,
     }
 }
 

--- a/infrastructure/src/database/schema.rs
+++ b/infrastructure/src/database/schema.rs
@@ -44,7 +44,7 @@ diesel::table! {
 diesel::table! {
     payment_requests (id) {
         id -> Uuid,
-        project_id -> Uuid,
+        budget_id -> Uuid,
         requestor_id -> Uuid,
         recipient_id -> Uuid,
         amount_in_usd -> Int8,
@@ -93,7 +93,7 @@ diesel::table! {
 }
 
 diesel::joinable!(budgets -> projects (project_id));
-diesel::joinable!(payment_requests -> projects (project_id));
+diesel::joinable!(payment_requests -> budgets (budget_id));
 diesel::joinable!(payments -> payment_requests (request_id));
 diesel::joinable!(project_leads -> projects (project_id));
 

--- a/infrastructure/src/event_store.rs
+++ b/infrastructure/src/event_store.rs
@@ -1,6 +1,6 @@
 use crate::database::{schema::events, Client};
 use diesel::prelude::*;
-use domain::{Aggregate, EventStore, EventStoreError, Payment, Project};
+use domain::{Aggregate, Budget, EventStore, EventStoreError, Payment, Project};
 use log::error;
 use serde_json::Value;
 
@@ -17,6 +17,12 @@ impl NamedAggregate for Project {
 impl NamedAggregate for Payment {
 	fn name() -> String {
 		String::from("PAYMENT")
+	}
+}
+
+impl NamedAggregate for Budget {
+	fn name() -> String {
+		String::from("BUDGET")
 	}
 }
 

--- a/macros/src/diesel_repository.rs
+++ b/macros/src/diesel_repository.rs
@@ -46,8 +46,15 @@ pub fn derive(input: TokenStream) -> TokenStream {
 	let expanded = quote! {
 		use crate::diesel::RunQueryDsl;
 		use crate::diesel::ExpressionMethods;
+		use crate::diesel::query_dsl::filter_dsl::FindDsl;
 
 		impl ::domain::EntityRepository<#entity_type> for #repository_name {
+			fn find_by_id(&self, id: &<#entity_type as ::domain::Entity>::Id) -> anyhow::Result<#entity_type> {
+				let connection = self.0.connection()?;
+				let entity = #table.find(*id).first(&*connection)?;
+				Ok(entity)
+			}
+
 			fn insert(&self, entity: &#entity_type) -> anyhow::Result<()> {
 				let connection = self.0.connection()?;
 				diesel::insert_into(#table).values(entity).execute(&*connection)?;

--- a/migrations/2022-11-28-161958_add-budget-in-project-projection/down.sql
+++ b/migrations/2022-11-28-161958_add-budget-in-project-projection/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE budgets;

--- a/migrations/2022-11-28-161958_add-budget-in-project-projection/up.sql
+++ b/migrations/2022-11-28-161958_add-budget-in-project-projection/up.sql
@@ -1,0 +1,19 @@
+CREATE TABLE budgets (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    project_id UUID REFERENCES projects(id),
+    initial_amount NUMERIC NOT NULL,
+    remaining_amount NUMERIC NOT NULL
+);
+
+-- Create budget for each project (consider half spent, or 1000 USD budget if no request yet)
+INSERT INTO
+    budgets (project_id, initial_amount, remaining_amount)
+    SELECT
+        projects.id as project_id,
+        coalesce(2*sum(amount_in_usd), 1000) AS initial_amount,
+        coalesce(sum(amount_in_usd), 1000) AS remaining_amount
+    FROM
+        projects
+        LEFT JOIN payment_requests ON payment_requests.project_id = projects.id
+    GROUP BY
+        projects.id;

--- a/migrations/2022-11-29-075812_make-payment-request-mandatory/down.sql
+++ b/migrations/2022-11-29-075812_make-payment-request-mandatory/down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE payments
+    ALTER COLUMN request_id DROP NOT NULL;

--- a/migrations/2022-11-29-075812_make-payment-request-mandatory/up.sql
+++ b/migrations/2022-11-29-075812_make-payment-request-mandatory/up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE payments
+    ALTER COLUMN request_id SET NOT NULL;

--- a/migrations/2022-11-29-094546_link-payment-to-budget/down.sql
+++ b/migrations/2022-11-29-094546_link-payment-to-budget/down.sql
@@ -1,0 +1,21 @@
+ALTER TABLE payment_requests RENAME TO payment_requests_backup;
+
+CREATE TABLE payment_requests (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    project_id UUID NOT NULL REFERENCES projects(id),
+    requestor_id uuid NOT NULL,
+    recipient_id uuid NOT NULL,
+    amount_in_usd int8 NOT NULL,
+    reason jsonb NOT NULL
+);
+
+INSERT INTO payment_requests
+    SELECT payment_requests_backup.id, budgets.project_id, requestor_id, recipient_id, amount_in_usd, reason
+    FROM payment_requests_backup
+    JOIN budgets ON budgets.id = payment_requests_backup.budget_id;
+
+ALTER TABLE payments
+    DROP CONSTRAINT payments_request_id_fkey,
+    ADD CONSTRAINT payments_request_id_fkey FOREIGN KEY (request_id) REFERENCES payment_requests(id);
+
+DROP TABLE payment_requests_backup;

--- a/migrations/2022-11-29-094546_link-payment-to-budget/up.sql
+++ b/migrations/2022-11-29-094546_link-payment-to-budget/up.sql
@@ -1,0 +1,21 @@
+ALTER TABLE payment_requests RENAME TO payment_requests_backup;
+
+CREATE TABLE payment_requests (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    budget_id UUID NOT NULL REFERENCES budgets(id),
+    requestor_id uuid NOT NULL,
+    recipient_id uuid NOT NULL,
+    amount_in_usd int8 NOT NULL,
+    reason jsonb NOT NULL
+);
+
+INSERT INTO payment_requests
+    SELECT payment_requests_backup.id, budgets.id, requestor_id, recipient_id, amount_in_usd, reason
+    FROM payment_requests_backup
+    JOIN budgets ON budgets.project_id = payment_requests_backup.project_id;
+
+ALTER TABLE payments
+    DROP CONSTRAINT payments_request_id_fkey,
+    ADD CONSTRAINT payments_request_id_fkey FOREIGN KEY (request_id) REFERENCES payment_requests(id);
+
+DROP TABLE payment_requests_backup;

--- a/testing/cypress/e2e/project_leader.cy.js
+++ b/testing/cypress/e2e/project_leader.cy.js
@@ -42,19 +42,4 @@ describe("As a project leader, I", () => {
             })
         });
     });
-
-
-    it("anyone cannot request a payment", () => {
-        cy.createUser().then(contributor => {
-            cy.graphqlAs(contributor, `mutation {
-                requestPayment(amountInUsd: 500, budgetId: "${budgetId}", recipientId: "${contributor.id}", requestorId: "${contributor.id}", reason: "{}")
-              }
-              `).its('body.errors').should($errors => {
-                expect($errors).to.have.length(1);
-                expect($errors[0].message).to.equal('User is not authorized to perform the action');
-                expect($errors[0].extensions.reason).to.equal('Project leader role required');
-
-            })
-        });
-    });
 });

--- a/testing/cypress/e2e/project_leader.cy.js
+++ b/testing/cypress/e2e/project_leader.cy.js
@@ -39,6 +39,15 @@ describe("As a project leader, I", () => {
                   }`)
                     .its('body.data.payment_requests_by_pk.id')
                     .should('be.a', 'string');
+            }).then(() => {
+                cy.wait(500);
+                cy.graphqlAsAdmin(`{
+                    budgets_by_pk(id:"${budgetId}") {
+                      remaining_amount
+                    }
+                  }`)
+                    .its('body.data.budgets_by_pk.remaining_amount')
+                    .should('equal', 500)
             })
         });
     });

--- a/testing/cypress/support/commands.js
+++ b/testing/cypress/support/commands.js
@@ -120,9 +120,9 @@ Cypress.Commands.add('addProjectLead', (projectId, userId) => {
     cy.graphqlAsAdmin(`mutation { assignProjectLead(leaderId: "${userId}", projectId: "${projectId}") }`);
 });
 
-Cypress.Commands.add('requestPayment', (requestor, projectId, amount, recipient, reason) => {
+Cypress.Commands.add('requestPayment', (requestor, budgetId, amount, recipient, reason) => {
     return cy.graphqlAs(requestor, `mutation {
-        requestPayment(amountInUsd: ${amount}, projectId: "${projectId}", recipientId: "${recipient.id}", requestorId: "${requestor.id}", reason: "{}")
+        requestPayment(amountInUsd: ${amount}, budgetId: "${budgetId}", recipientId: "${recipient.id}", requestorId: "${requestor.id}", reason: "${reason}")
       }
       `).its('body.data.requestPayment').should('be.a', 'string');
 });


### PR DESCRIPTION
* Create budget aggregate root and projection
* Check remaining amount when spending budget
* Spend budget when requesting a payment
* The payment requets projection is now linked to a budget (instead of a project). The budget is linked to a project.
* Removed `project_exists` specification as checked by the budget event sourcing logic

I had to remove the access control on `Payment::request` as we need to refine how a budget can be linked to a user (owner?)

Commits:
- 🚚 move amount as value object
- ✨ create budget aggregate
- ✨ allocate budget upon project creation
- 🗃️ create budget projection
- ♻️ use derive_new to remove boilerplate
- ✨ create budget projection
- 🔧 track budgets table in hasura
- 🗃️ make request_id mandatory in payments projection
- ✨ implement find_by_id in diesel repository
- ✨ event source budget and update projection on spend
- 🗃️ link payment request projection to budget instead of project
- 🔥 remove project exists spec
- 🔥 remove access control check when requesting payment
- ✨ spend budget when requesting payment
