### PR TITLE
Tolerate an error from Coinmarketcap when processing a Budget allocation event

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -25,6 +25,7 @@ env:
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
   AWS_REGION: ${{ secrets.AWS_REGION }}
+  COINMARKETCAP_API_KEY: ${{ secrets.COINMARKETCAP_API_KEY }}
 
 jobs:
   format:

--- a/api/src/presentation/event_listeners/quote_syncer.rs
+++ b/api/src/presentation/event_listeners/quote_syncer.rs
@@ -31,7 +31,7 @@ impl EventListener<Event> for Projector {
 							.quote_service
 							.fetch_conversion_rate(currency)
 							.await
-							.map_err(SubscriberCallbackError::Fatal)?;
+							.unwrap_or_default();
 
 						self.quotes_repository.insert(CryptoUsdQuote {
 							currency: code,


### PR DESCRIPTION
=> en cas d'erreur, la currency sera quand meme insérée en base, avec un taux de change à zéro.
=> le CRON job de mise a jour des currencies viendra remettre le bon taux automatiquement par la suite.

This is a quick-win to prevent the incident that occured (in develop) on Friday Oct. 27th from occuring again.

Here is what happened:
- à partir de 15h29 aujourd'hui, nous avons commencé à avoir des erreurs 401 de CoinMarketCap nous disant que notre API-KEY est invalide
- l'event-listener qui gere ca (dans l'ancienne API) se met à faire du retry un peu agressif
- en conséquence, en plus des 401, on commence à se prendre des 429 de CoinMarketCap
- et coté RabbitMQ, manifestement on gère mal le retry car de nouveaux channels sont ouverts à chaque fois (en gros les anciens channels ne sont pas drop), et on fini par atteindre le max de channels qu'on peut ouvrir, c'est à dire 200.

A noter qu'on a donc également un soucis général avec le retry qui ne close pas les channel RabbitMQ.
