### PR TITLE
Remove the need to send a JWT when calling request_payment, cancel_payment and mark_invoice_as_received

### DIFF
--- a/api/src/presentation/http/mod.rs
+++ b/api/src/presentation/http/mod.rs
@@ -117,7 +117,6 @@ pub fn serve(
 		.mount(
 			"/api",
 			routes![
-				routes::users::profile_picture,
 				routes::users::update_user_profile,
 				routes::users::update_user_payout_info,
 				routes::users::search_users,

--- a/api/src/presentation/http/routes/payment/cancel.rs
+++ b/api/src/presentation/http/routes/payment/cancel.rs
@@ -1,11 +1,10 @@
-use domain::{AggregateRepository, Payment};
 use http_api_problem::{HttpApiProblem, StatusCode};
-use presentation::http::guards::{ApiKey, Claims, Role};
-use rocket::{serde::json::Json, State};
+use presentation::http::guards::ApiKey;
+use rocket::serde::json::Json;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::{application, domain::permissions::IntoPermission};
+use crate::application;
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -17,24 +16,9 @@ pub struct Response {
 pub async fn cancel_payment(
 	_api_key: ApiKey,
 	payment_id: Uuid,
-	claims: Option<Claims>,
-	role: Role,
 	usecase: application::payment::cancel::Usecase,
-	payment_repository: &State<AggregateRepository<Payment>>,
 ) -> Result<Json<Response>, HttpApiProblem> {
 	let payment_id = payment_id.into();
-
-	if !role
-		.to_permissions((*payment_repository).clone())
-		.can_cancel_payment(&payment_id)
-	{
-		return Err(HttpApiProblem::new(StatusCode::UNAUTHORIZED)
-			.title("Unauthorized operation on project")
-			.detail(format!(
-				"User {} needs project lead role to cancel a payment request",
-				claims.map(|c| c.user_id).unwrap_or_default(),
-			)));
-	}
 
 	let command_id = usecase.cancel(&payment_id).await.map_err(|e| {
 		HttpApiProblem::new(StatusCode::INTERNAL_SERVER_ERROR)

--- a/api/src/presentation/http/routes/payment/request.rs
+++ b/api/src/presentation/http/routes/payment/request.rs
@@ -1,13 +1,11 @@
-use domain::{
-	AggregateRepository, CommandId, Currency, GithubUserId, Payment, PaymentId, ProjectId,
-};
+use domain::{CommandId, Currency, GithubUserId, PaymentId, ProjectId, UserId};
 use http_api_problem::{HttpApiProblem, StatusCode};
-use presentation::http::guards::{ApiKey, Claims, Role};
-use rocket::{serde::json::Json, State};
+use presentation::http::guards::ApiKey;
+use rocket::serde::json::Json;
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
 
-use crate::{application, domain::permissions::IntoPermission, presentation::http::dto};
+use crate::{application, presentation::http::dto};
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -21,6 +19,7 @@ pub struct Response {
 pub struct Request {
 	project_id: ProjectId,
 	recipient_id: GithubUserId,
+	requestor_id: UserId,
 	amount: Decimal,
 	currency: &'static Currency,
 	hours_worked: Option<u32>,
@@ -31,38 +30,22 @@ pub struct Request {
 pub async fn request_payment(
 	_api_key: ApiKey,
 	request: Json<Request>,
-	claims: Claims,
-	role: Role,
-	payment_repository: &State<AggregateRepository<Payment>>,
 	request_payment_usecase: application::payment::request::Usecase,
 ) -> Result<Json<Response>, HttpApiProblem> {
 	let Request {
 		project_id,
 		recipient_id,
+		requestor_id,
 		amount,
 		currency,
 		hours_worked,
 		reason,
 	} = request.into_inner();
 
-	let caller_id = claims.user_id;
-
-	if !role
-		.to_permissions((*payment_repository).clone())
-		.can_spend_budget_of_project(&project_id)
-	{
-		return Err(HttpApiProblem::new(StatusCode::UNAUTHORIZED)
-			.title("Unauthorized operation on project")
-			.detail(format!(
-				"User {} needs project lead role to create a payment request on project {}",
-				caller_id, project_id
-			)));
-	}
-
 	let (payment_id, command_id) = request_payment_usecase
 		.request(
 			project_id,
-			caller_id,
+			requestor_id,
 			recipient_id,
 			amount,
 			currency,
@@ -98,21 +81,9 @@ pub struct InvoiceReceivedRequest {
 pub async fn mark_invoice_as_received(
 	_api_key: ApiKey,
 	request: Json<InvoiceReceivedRequest>,
-	role: Role,
-	payment_repository: &State<AggregateRepository<Payment>>,
 	invoice_payment_usecase: application::payment::invoice::Usecase,
 ) -> Result<(), HttpApiProblem> {
 	let InvoiceReceivedRequest { payments } = request.into_inner();
-
-	let caller_permissions = role.to_permissions((*payment_repository).clone());
-
-	if payments
-		.iter()
-		.any(|payment_id| !caller_permissions.can_mark_invoice_as_received_for_payment(payment_id))
-	{
-		return Err(HttpApiProblem::new(StatusCode::UNAUTHORIZED)
-			.title("Only recipient can mark invoice as received"));
-	}
 
 	invoice_payment_usecase.mark_invoice_as_received(payments).await.map_err(|e| {
 		{

--- a/api/tests/context/utils.rs
+++ b/api/tests/context/utils.rs
@@ -5,6 +5,8 @@ use rocket::{http::Header, serde::json::json};
 
 use super::API_KEY;
 
+pub const USER_ID: &str = "9b7effeb-963f-4ac4-be74-d735501925ed";
+
 #[allow(unused)]
 pub fn jwt(project_leaded_id: Option<String>) -> String {
 	let now = SystemTime::now()
@@ -27,10 +29,10 @@ pub fn jwt(project_leaded_id: Option<String>) -> String {
 			  "registered_user"
 			],
 			"x-hasura-default-role": "registered_user",
-			"x-hasura-user-id": "9b7effeb-963f-4ac4-be74-d735501925ed",
+			"x-hasura-user-id": USER_ID,
 			"x-hasura-user-is-anonymous": "false"
 		  },
-		  "sub": "9b7effeb-963f-4ac4-be74-d735501925ed",
+		  "sub": USER_ID,
 		  "iat": now,
 		  "exp": now + 1000,
 		  "iss": "hasura-auth-unit-tests"


### PR DESCRIPTION
See https://github.com/onlydustxyz/marketplace-api/pull/258